### PR TITLE
Loops (mostly)

### DIFF
--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -52,6 +52,7 @@ from chb.app.DerivedGraphSequence import DerivedGraphSequence
 import chb.ast.ASTNode as AST
 from chb.astinterface.ASTInterface import ASTInterface
 
+import chb.util.tingly as tingly
 
 import chb.invariants.XXprUtil as XU
 
@@ -59,7 +60,6 @@ import chb.util.fileutil as UF
 
 if TYPE_CHECKING:
     from chb.app.Function import Function
-
 
 class Cfg:
 
@@ -144,35 +144,429 @@ class Cfg:
         else:
             return []
 
+    def analyze_loops(self):
+        rg = tingly.RootedDiGraph(self.derived_graph_sequence.nodes,
+                                    self.derived_graph_sequence.edges,
+                                    self.derived_graph_sequence.graphs[0].nodes[0])
+        ipostdoms = rg.ipostdoms()
+
+        def initial_loop_header_identification() -> Tuple[Dict[str, int], Set[Tuple[str, str]]]:
+            loopdepths : Dict[str, int] = {}
+            loopcandidates : Set[Tuple[str, str]] = set()
+
+            for n, gn in enumerate(self.derived_graph_sequence.graphs):
+                for header, gin in gn.intervals.items():
+                    print(f'header for interval at graph level {n=} is {header=}')
+                    for src in gin.edges:
+                        for tgt in gin.edges[src]:
+                            print(' ' * n + f"considering edge {src=} -> {tgt=} at loop level {n=}")
+                            if tgt == header:
+                                assert (header not in loopdepths or loopdepths[header] == n)
+                                loopdepths[header] = n
+                                # The src node is in an interval at level n, but we're ultimately
+                                # interested in the node(s) within the equivalent interval(s) at
+                                # level 0.
+                                loopcandidates.add( (header, src) )
+            return loopdepths, loopcandidates
+
+        def expand_interval_nodes(node, level) -> List[str]:
+            return self.derived_graph_sequence.graphs[level - 1].intervals[node].nodes
+
+        def find_level_0_backedges(loopcandidates : List[Tuple[str, str]],
+                                   loopdepths : Dict[str, int]
+                                  ) -> List[Tuple[int, Tuple[str, str]]]:
+            backedge_levels : List[Tuple[int, str, str]] = []
+            for hdr, src_n in loopcandidates:
+                # The worklist contains interval nodes targeting hdr with a backedge.
+                # For interval depths > 0, we need to (recursively) peek inside the
+                # interval to find the node within it which contains the backedge.
+                worklist = [ (src_n, loopdepths[hdr], loopdepths[hdr]) ]
+                while len(worklist) > 0:
+                    (src, n, norig) = worklist.pop()
+                    if n == 0:
+                        print(f"found level-0 backedge from {src} to {hdr}")
+                        backedge_levels.append( (norig, (src, hdr)) )
+                    else:
+                        for node in expand_interval_nodes(src, n):
+                            for tgt in self.successors(node):
+                                if tgt == hdr:
+                                    print(f"found backedge at level {n-1=} from {node} to {hdr}")
+                                    worklist.append( (node, n - 1, norig) )
+            return backedge_levels
+
+        def determine_loop_circuit(
+                    backedge_levels: List[Tuple[int, str, str]]
+                ) -> Dict[str, List[str]]:
+            incircuit : Dict[str, List[str]] = {}
+            preds = self.derived_graph_sequence.graphs[0].revedges
+
+            # We iterate by level to ensure that each node
+            # is associated with the innermost nested loop which contains it.
+            backedge_levels.sort(key=lambda tup: tup[0])
+
+            # The nodes in a loop's circuit are found by iterating backwards from
+            # the latch until we find the header.
+            for _level, (src_n, header) in backedge_levels:
+                print(f'         collecting circuit body of {_level, (src_n, header)=}')
+                worklist = [src_n]
+                seen = set(worklist)
+                while worklist:
+                    node = worklist.pop()
+                    if not node in incircuit:
+                        incircuit[node] = []
+                    incircuit[node].append(header)
+                    if node != header:
+                        for prev in preds[node]:
+                            if not prev in seen:
+                                seen.add(prev)
+                                worklist.append(prev)
+
+            return incircuit
+
+        def determine_loop_scope(
+                    backedge_levels: List[Tuple[int, str, str]],
+                    afterloop: Dict[str, Optional[str]]
+                ) -> Dict[str, List[str]]:
+            inscope : Dict[str, List[str]] = {}
+            succs = self.derived_graph_sequence.graphs[0].edges
+
+            header_levels = list(set((level, header) for level, (_, header) in backedge_levels))
+            headers = set(header for _, header in header_levels)
+
+            # We iterate by level to ensure that each node
+            # is associated with the innermost nested loop which contains it.
+            # Largest first, because that's the nature of syntax.
+            header_levels.sort(key=lambda tup: tup[0], reverse=True)
+
+            # The nodes in a loop's scope are found by iterating forwards from
+            # the header until we find the the follow.
+            for _level, header in header_levels:
+                other_headers = headers - {header}
+                worklist = [header]
+                seen = set(worklist)
+                print(f'         collecting scope body of {(_level, header)=}; {other_headers=}')
+
+                def known_different_scope(node):
+                    return node == afterloop[header] or node in other_headers
+
+                while worklist:
+                    node = worklist.pop()
+                    if not node in inscope:
+                        inscope[node] = []
+                    if known_different_scope(node):
+                        continue
+                    print(f'             marking {node=} as part of scope of {header=}')
+                    inscope[node].append(header)
+                    for next in succs[node]:
+                        if not next in seen:
+                            seen.add(next)
+                            worklist.append(next)
+
+            return inscope
+
+        def classify_loop(src, header, n: int, ipostdoms) -> str:
+            print(f"loop candidate {header=} found at graph level {n=} with backedge from {src=}")
+
+            hdrlen = len(self.successors(header))
+            latchlen = len(self.successors(src))
+            if ipostdoms[header] == None:
+                return 'endless'
+            elif hdrlen == 2 and latchlen == 1:
+                return 'while'
+            elif hdrlen == 1 and latchlen == 2:
+                return 'do-while'
+            elif hdrlen == 1 and latchlen == 1:
+                # Probably a while-like loop, albeit with an internal goto somewhere;
+                # the fact that the postdominator exists implies that it's possible to
+                # exit the loop.
+                return 'internal-control'
+            else:
+                if hdrlen == 2 and latchlen == 2 and header == src:
+                    # Some while loops get optimized to a single self-looping node.
+                    return 'while'
+
+                return 'undetermined'
+
+        def determine_loopfollow(src, hdr, inloop, looptype) -> Optional[str]:
+            """The follow node is the one which executes on the way out of the loop.
+               The follow may be printed within the sytactic block of the loop,
+               or it may be the statement after the loop (targeted by a break).
+               The loopfollow is not owned by the loop, even when printed within it."""
+            if looptype == 'while':
+                succs = self.successors(hdr)
+                assert len(succs) == 2
+                if succs[0] in inloop and inloop[succs[0]][0] == hdr:
+                    return succs[1]
+                else:
+                    return succs[0]
+            elif looptype == 'do-while':
+                succs = self.successors(src)
+                assert len(succs) == 2
+                if succs[0] in inloop and inloop[succs[0]][0] == hdr:
+                    return succs[1]
+                else:
+                    return succs[0]
+            elif looptype == 'endless':
+                return None
+            elif looptype == 'internal-control':
+                return ipostdoms[hdr]
+            else:
+                return None
+
+        loopdepths, loopcandidates = initial_loop_header_identification()
+        backedge_levels = find_level_0_backedges(loopcandidates, loopdepths)
+        incircuit = determine_loop_circuit(backedge_levels)
+        
+        import pprint
+        print(f"incircuit:")
+        pprint.pprint(incircuit, indent=4)
+        print(f"{loopcandidates=}")
+        print(f"{backedge_levels=}")
+
+        loopsignatures = []
+        for norig, (src, hdr) in backedge_levels:
+            looptype = classify_loop(src, hdr, norig, ipostdoms)
+
+            if hdr in incircuit and incircuit[hdr][0] != hdr:
+                print(f"           discarding loop candidate {(hdr,src,looptype,norig)=} since the header belongs to another loop ({incircuit[hdr]})")
+            elif src in incircuit and incircuit[src][0] != hdr:
+                print(f"           discarding loop candidate {(hdr,src,looptype,norig)=} since the latch belongs to another loop ({incircuit[src]})")
+            else:
+                loopfollow = determine_loopfollow(src, hdr, incircuit, looptype)
+                loopsignatures.append( (hdr, src, looptype, loopfollow, norig) )
+
+        
+        loopfollows = {}
+        for hdr, src, looptype, loopfollow, norig in loopsignatures:
+            loopfollows[hdr] = loopfollow
+
+        afterloop = {}
+        for hdr in loopfollows.keys():
+            pdom = ipostdoms[hdr]
+            while pdom != None and pdom in incircuit and hdr in incircuit[pdom]:
+                pdom = ipostdoms[pdom]
+            afterloop[hdr] = pdom
+        afterloop.setdefault(None)
+
+        inscope = determine_loop_scope(backedge_levels, afterloop)
+        print(f"inscope:")
+        pprint.pprint(inscope, indent=4)
+
+
+        print(f"loopsignatures:")
+        pprint.pprint(loopsignatures, indent=4)
+        
+        backedges = set(edge for _, edge in backedge_levels)
+        return (incircuit, inscope, backedges, loopsignatures, loopfollows, afterloop, rg)
+
+    def is_returning(self, stmt: AST.ASTStmt) -> bool:
+        if isinstance(stmt, AST.ASTReturn):
+            return True
+        if isinstance(stmt, AST.ASTBlock):
+            return self.is_returning(stmt.stmts[-1])
+        return False
+
     def stmt_ast(
             self,
             fn: "Function",
             astree: ASTInterface,
             blockstmts: Dict[str, AST.ASTStmt]) -> AST.ASTNode:
-        twowayconds = self.derived_graph_sequence.two_way_conditionals()
+        
+        self.derived_graph_sequence.to_dot("/home/ben/", "nustmtast")
+        for id in blockstmts.keys():
+            from chb.ast.ASTCPrettyPrinter import ASTCPrettyPrinter
+            pp = ASTCPrettyPrinter(astree.astree.symboltable)
+            pp.stmt_to_c(blockstmts[id])
+            sep = "\n     "
+            c = sep.join(str(pp.ccode).split("\n"))
+            print(f'{id} ==>{sep}{c}')
 
+        incircuit, inscope, all_backedges, loopsignatures, loopfollows, afterloop, rg = self.analyze_loops()
+        
+        def loop_scope_for_node_is(n: str, tgt: str) -> bool:
+            return n in inscope and len(inscope[n]) > 0 and inscope[n][0] == tgt
+
+        idoms = rg.idoms
+        ipostdoms = rg.ipostdoms()
+
+        print(f"{idoms=}")
+        print(f'{ipostdoms=}')
+        import pprint
+        pprint.pprint(rg._edge_flavors, indent=4)
+
+        print(f'loopfollows:')
+        pprint.pprint(loopfollows, indent=4)
+        print(f'afterloop:')
+        pprint.pprint(afterloop, indent=4)
+
+        loopheaders = set(sig[0] for sig in loopsignatures)
+        latchingnodes = set(src for src, tgt in all_backedges)
+        twowayconds = rg.two_way_conditionals(loopheaders, latchingnodes)
+
+        print(f'twowayconds:')
+        pprint.pprint(twowayconds, indent=4)
+
+        gotoedges = set()
+        # Some edges into multi-predecessor nodes must become gotos.
+        # Backedges within a loop don't count; they are implicitly represented
+        # (and, if not, would be represented with `continue`s). But we might need
+        # a goto for a backedge that crosses between loops.
+        # Similarly, the join points for two-way conditionals are exempt.
+        # For the remainder, one arbitrarily chosen edge is exempt, and the others
+        # must use gotos.
+        ifjoinpoints = set(twowayconds.values())
+        print(f'{ifjoinpoints=}')
+        for tgt in rg.rpo_sorted: # outer
+            print(f'considering goto target {tgt}')
+            preds = rg.pre(tgt)
+            if len(preds) <= 1 or tgt in ifjoinpoints:
+                continue # to outer
+            print(f'{len(preds)=} for {tgt=}')
+
+            # If any predecessor is a tree edge, the others need gotos.
+            # If none are tree edges, one will be chosen arbitrarily
+            # to not need a goto.
+            exempted_one_pred = any(rg.edge_flavor(p, tgt) == 'tree' for p in preds)
+
+            for p in preds: # inner
+                edge = (p, tgt)
+                if rg.edge_flavor(p, tgt) == 'tree':
+                    print(f'tree {edge=} cannot be a goto')
+                    continue
+                if edge in all_backedges:
+                    if loop_scope_for_node_is(p, tgt):
+                        print(f"      skipping edge {edge=} because the pred is in the scope of the target")
+                        continue # to inner
+                    else:
+                        print(f"  not skipping edge {edge=} because the pred is not in the scope of the target")
+                if not exempted_one_pred:
+                    exempted_one_pred = True
+                    print(f"     exempting edge {edge=} from gotos because it was the first leading to the target")
+                else:
+                    print(f"     adding goto edge {edge=}")
+                    gotoedges.add(edge)
+        print(f"######## eventually got {gotoedges=}")
+
+        non_goto_backedges = all_backedges - gotoedges
+
+        labeled_stmts = set(tgt for _, tgt in gotoedges)
+
+        breakedges = set()
+        # For each loop header, the break target is the first *out of the loop*
+        # postdominating node, and the break edges are those *from in the loop*
+        # targeting it.
+        for hdr in loopheaders:
+            pdom = afterloop[hdr]
+            print(f"::break target for {hdr=} is {pdom=} {inscope[pdom] if pdom in inscope else None}")
+            for src in rg.edges:
+                for tgt in rg.edges[src]:
+                    if tgt == pdom:
+                        # The src node need not be "owned" by the loop, since non-owned
+                        # nodes can appear within the syntactic scope of the loop.
+                        if rg.dominates(hdr, src) and not rg.dominates(pdom, src):
+                            print(f"::::adding break edge owned by {hdr=} : {(src,tgt)=}")
+                            breakedges.add( (src, tgt) )
+
+        def emit(n: str) -> List[AST.ASTStmt]:
+            if n in labeled_stmts:
+                return [astree.mk_label_stmt(n), blockstmts[n]]
+            return [blockstmts[n]]
+
+        constructed_stmts = set()
         def construct(
                 n: str,
                 follow: Optional[str],
+                loopheader: Optional[str],
                 result: List[AST.ASTStmt]) -> AST.ASTStmt:
+            # `follow` is a marker indicating the join point of an `if` branch.
+
+            def possible_loop_latch_branch(succ, follownode) -> AST.ASTStmt:
+                if (n, succ) in non_goto_backedges:
+                    # don't infinitely recurse!
+                    return astree.mk_block([])
+
+                if (n, succ) in breakedges:
+                        print(f"emitting break at edge {n=}->{succ=}  {loopheader=}")
+                        print(f"    {inscope[n] if n in inscope else None=}")
+                        print(f"    {inscope[succ] if succ in inscope else None=}")
+                        return astree.mk_break_stmt()
+
+                return construct(succ, follownode, loopheader, [])
+
+            print(f"construct({n=}, {follow=}, {loopheader=})")
             if follow and n == follow:
                 return astree.mk_block(result)
-            elif len(self.successors(n)) == 0:
-                return astree.mk_block(result + [blockstmts[n]])
-            elif len(self.successors(n)) == 1:
-                return construct(
-                    self.successors(n)[0], follow, result + [blockstmts[n]])
+
+            if n in constructed_stmts:
+                print(f"###########################  already constructed {n=}; emitting an unexpected goto")
+                return astree.mk_block(result + [astree.mk_goto_stmt(n)])
+            else:
+                constructed_stmts.add(n)
+
+            if len(self.successors(n)) == 0:
+                return astree.mk_block(result + emit(n))
+
+            if loop_scope_for_node_is(n, n) and loopheader != n:
+                # Loop headers are those for which `inloop[n][0] == n`.
+                # When we encounter it the first time, we recur with
+                # a new `loopheader` flag so that we don't infinitely recurse.
+                print(f"encountered loop header node {n=}, {len(result)=}")
+                follownode = afterloop[n]
+                print(f'{follownode=} for {n=} ; {loopheader=}')
+                constructed_stmts.remove(n)
+                body = construct(n, follow, n, [])
+                loop = astree.mk_loop(body)
+                if follownode:
+                    # In rare cases, the follow node may have multiple predecessors.
+                    # In order to avoid emitting the same nodes multiple times, we
+                    # need to instead emit a goto for all but one of the predecessor
+                    # loops.
+
+
+                    # Continue slurping up nodes past the loop we just constructed
+                    return construct(
+                        follownode, follow, loopheader, result + [loop])
+                else:
+                    # No more nodes to slurp up; return what we have so far, plus our loop
+                    if result == []:
+                        return loop
+                    return astree.mk_block(result + [loop])
+                assert False # make sure we don't accidentally fall through!
+
+            if len(self.successors(n)) == 1:
+                next = self.successors(n)[0]
+                if (n, next) in non_goto_backedges:
+                    if loopheader == next:
+                        print(f"ending construct early at {n=} {next=} due to backedge...")
+                        return astree.mk_block(result + emit(n))
+                    else:
+                        print(f"ending construct early (different loopheader) at {n=} {next=} due to backedge...")
+                        return astree.mk_block(result + emit(n))
+
+                if (n, next) in breakedges:
+                        print(f"emitting break at edge {n=}->{next=}  {loopheader=}")
+                        print(f"    {inscope[n] if n in inscope else None=}")
+                        print(f"    {inscope[next] if next in inscope else None=}")
+                        return astree.mk_block(result + emit(n) + [astree.mk_break_stmt()])
+
+                if (n, next) in gotoedges:
+                    print(f"ending construct early at {n=} due to goto...")
+                    return astree.mk_block(result + emit(n) + [astree.mk_goto_stmt(next)])    
+
+                print((n,next), 'was not in gotoedges')
+                return construct(next, follow, loopheader, result + emit(n))
+
             elif len(self.successors(n)) == 2:
                 if n in twowayconds:
                     follownode: Optional[str] = twowayconds[n]
                 else:
                     follownode = None
-                ifbranch = construct(self.successors(n)[1], follownode, [])
-                elsebranch = construct(self.successors(n)[0], follownode, [])
-                pcoffset = (
-                    (int(self.successors(n)[1], 16)
-                     - int(self.successors(n)[0], 16))
-                    - 2)
+                truside = self.successors(n)[1]
+                falside = self.successors(n)[0]
+                ifbranch = possible_loop_latch_branch(truside, follownode)
+                elsebranch = possible_loop_latch_branch(falside, follownode)
+
+                pcoffset = ( (int(truside, 16) - int(falside, 16)) - 2)
                 if ifbranch.is_empty():
                     condition = fn.blocks[n].assembly_ast_condition(
                         astree, reverse=True)
@@ -199,15 +593,17 @@ class Cfg:
                 branchinstr = fn.blocks[n].last_instruction
                 astree.add_instruction_span(
                     bstmt.assembly_xref, branchinstr.iaddr, branchinstr.bytestring)
+
+                print(f',,,,,, handling continuation of 2-succ node {n=} {loopheader=} {follownode=} {follow=}')
                 if follownode:
                     return construct(
-                        follownode, follow, result + [blockstmts[n], bstmt])
+                        follownode, follow, loopheader, result + emit(n) + [bstmt])
                 else:
-                    return astree.mk_block(result + [blockstmts[n], bstmt])
+                    return astree.mk_block(result + emit(n) + [bstmt])
             else:
                 raise UF.CHBError("Multi branch for " + n)
 
-        return construct(self.faddr, None, [])
+        return construct(self.faddr, None, None, [])
 
     def assembly_ast(
             self,

--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -443,8 +443,8 @@ class Cfg:
 
         loopheaders = set(sig[0] for sig in loopsignatures)
         latchingnodes = set(src for src, tgt in all_backedges)
-        print(f'{loopheaders=} ; {latchingnodes=}')
-        twowayconds = rg.two_way_conditionals(loopheaders, latchingnodes)
+        print(f'{loopheaders=} ; {latchingnodes=} (ndet ok)')
+        twowayconds = rg.two_way_conditionals(latchingnodes)
 
         print(f'twowayconds:')
         pprint.pprint(twowayconds, indent=4)

--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -603,9 +603,7 @@ class Cfg:
                 return astree.mk_block(result)
 
             if n in constructed_stmts:
-                #print(f"###########################  already constructed {n=}; emitting an unexpected goto")
-                labeled_stmts[n]._printed = True
-                return astree.mk_block(result + [astree.mk_goto_stmt(n)])
+                assert False, "missed a goto edge somewhere, visited node twice: " + n
             else:
                 constructed_stmts.add(n)
 

--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -156,7 +156,8 @@ class Cfg:
             loopcandidates : Set[Tuple[str, str]] = set()
 
             for n, gn in enumerate(self.derived_graph_sequence.graphs):
-                for header, gin in gn.intervals.items():
+                for header in sorted(gn.intervals.keys()):
+                    gin = gn.intervals[header]
                     print(f'header for interval at graph level {n=} is {header=}')
                     for src in gin.edges:
                         for tgt in gin.edges[src]:
@@ -470,22 +471,22 @@ class Cfg:
             # to not need a goto.
             exempted_one_pred = any(rg.edge_flavor(p, tgt) == 'tree' for p in preds)
 
-            for p in preds: # inner
+            for p in sorted(preds): # inner
                 edge = (p, tgt)
                 if rg.edge_flavor(p, tgt) == 'tree':
                     print(f'tree {edge=} cannot be a goto')
                     continue
                 if edge in all_backedges:
                     if loop_scope_for_node_is(p, tgt):
-                        print(f"      skipping edge {edge=} because the pred is in the scope of the target")
+                        print(f"      skipping {edge=} because the pred is in the scope of the target")
                         continue # to inner
                     else:
-                        print(f"  not skipping edge {edge=} because the pred is not in the scope of the target")
+                        print(f"  not skipping {edge=} because the pred is not in the scope of the target")
                 if not exempted_one_pred:
                     exempted_one_pred = True
-                    print(f"     exempting edge {edge=} from gotos because it was the first leading to the target")
+                    print(f"     exempting {edge=} from gotos because it was the first leading to the target")
                 else:
-                    print(f"     adding goto edge {edge=}")
+                    print(f"     adding goto {edge=}")
                     gotoedges.add(edge)
         print(f"######## eventually got {gotoedges=}")
 

--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -449,7 +449,11 @@ class Cfg:
 
         non_goto_backedges = all_backedges - gotoedges
 
-        labeled_stmts = set(tgt for _, tgt in gotoedges)
+        # Cifuentes used mutable state to toggle labels as needed when used
+        # by gotos. We generate label AST nodes before the gotos are emitted, so we
+        # need a conservative approximation of the labels that might be used.
+        cross_edges = set(e for e, flavor in rg._edge_flavors.items() if flavor == 'cross')
+        labeled_stmts = set(tgt for _, tgt in gotoedges | cross_edges)
 
         breakedges = set()
         # For each loop header, the break target is the first *out of the loop*

--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -113,10 +113,10 @@ class LoopAnalysis:
         for n, gn in enumerate(self.derived_graph_sequence.graphs):
             for header in sorted(gn.intervals.keys()):
                 gin = gn.intervals[header]
-                print(f'header for interval at graph level {n=} is {header=}')
+                # print(f'header for interval at graph level {n=} is {header=}')
                 for src in gin.edges:
                     for tgt in gin.edges[src]:
-                        print(' ' * n + f"considering edge {src=} -> {tgt=} at loop level {n=}")
+                        # print(' ' * n + f"considering edge {src=} -> {tgt=} at loop level {n=}")
                         if tgt == header:
                             assert (header not in loopdepths or loopdepths[header] == n)
                             loopdepths[header] = n
@@ -143,15 +143,14 @@ class LoopAnalysis:
             while len(worklist) > 0:
                 (src, n, norig) = worklist.pop()
                 if n == 0:
-                    print(f"found level-0 backedge from {src} to {hdr}")
+                    # print(f"found level-0 backedge from {src} to {hdr}")
                     backedge_levels.append( (norig, (src, hdr)) )
                 else:
                     for node in expand_interval_nodes(src, n):
                         if hdr in fg.post(node):
-                            print(f"found backedge at level {n-1=} from {node} to {hdr}")
+                            # print(f"found backedge at level {n-1=} from {node} to {hdr}")
                             worklist.append( (node, n - 1, norig) )
         return backedge_levels
-
 
     def _determine_loop_circuit(self, fg,
                 backedge_levels: List[Tuple[int, str, str]]
@@ -167,7 +166,7 @@ class LoopAnalysis:
         # The nodes in a loop's circuit are found by iterating backwards from
         # the latch until we find the header.
         for _level, (src_n, header) in backedge_levels:
-            print(f'         collecting circuit body of {_level, (src_n, header)=}')
+            # print(f'         collecting circuit body of {_level, (src_n, header)=}')
             worklist = [src_n]
             seen = set(worklist)
             while worklist:
@@ -178,7 +177,7 @@ class LoopAnalysis:
                     incircuit[node] = []
                 incircuit[node].append(header)
                 if node != header:
-                    print("         adding unseen predecessors of", node, "to worklist:", [p for p in preds[node] if not p in seen])
+                    # print("         adding unseen predecessors of", node, "to worklist:", [p for p in preds[node] if not p in seen])
                     for prev in preds[node]:
                         if not prev in seen:
                             seen.add(prev)
@@ -209,7 +208,7 @@ class LoopAnalysis:
             other_headers = headers - {header}
             worklist = [header]
             seen = set(worklist)
-            print(f'         collecting scope body of {(_level, header)=}; {other_headers=}')
+            # print(f'         collecting scope body of {(_level, header)=}; {other_headers=}')
 
             def process(n):
                 if not n in seen:
@@ -230,12 +229,12 @@ class LoopAnalysis:
                             continue
                         if len(rg.pre(next)) == 1:
                             #assert next not in owners
-                            print(f"while determining loop scope, updating afterloop[{node}] to {next}")
+                            # print(f"while determining loop scope, updating afterloop[{node}] to {next}")
                             afterloop[node] = next
                             process(next)
                     continue
 
-                print(f'             marking {node=} as part of scope of {header=}')
+                # print(f'             marking {node=} as part of scope of {header=}')
                 inscope[node].append(header)
                 for next in succs[node]:
                     process(next)
@@ -243,7 +242,7 @@ class LoopAnalysis:
         return inscope
 
     def _classify_loop(src, header, n: int, ipostdoms, fg) -> str:
-        print(f"loop candidate {header=} found at graph level {n=} with backedge from {src=}")
+        # print(f"loop candidate {header=} found at graph level {n=} with backedge from {src=}")
 
         hdrlen = len(fg.post(header))
         latchlen = len(fg.post(src))
@@ -328,15 +327,15 @@ class LoopAnalysis:
         # exit blocks accessible via inner loops. The exit sequence can occur purely within
         # the inner loop, or it may be placed after the outer loop.
         # (An example test case is cram-tests/codehawk-lifting/loops-gotos-c).
-        # The afterloop node for a loop header does not always match the join point
+        # Note that the afterloop node for a loop header often does does match the join point
         # of the header's conditional node.
         
         inscope = self._determine_loop_scope(fg, backedge_levels, afterloop, incircuit)
         backedges = set(edge for _, edge in backedge_levels)
 
-        import pprint
-        print(f"incircuit:")
-        pprint.pprint(incircuit, indent=4)
+        # import pprint
+        # print(f"incircuit:")
+        # pprint.pprint(incircuit, indent=4)
 
         return (inscope, backedges, loopsignatures, loopfollows, afterloop, ipostdoms)
 
@@ -348,13 +347,13 @@ class LoopAnalysis:
         # For the remainder, one arbitrarily chosen edge is exempt, and the others
         # must use gotos.
         ifjoinpoints = set(twowayconds.values())
-        print(f'{ifjoinpoints=}')
+        # print(f'{ifjoinpoints=}')
         for tgt in rg.rpo_sorted: # outer
-            print(f'considering goto target {tgt}')
+            # print(f'considering goto target {tgt}')
             preds = rg.pre(tgt)
             if len(preds) <= 1 or tgt in ifjoinpoints:
                 continue # to outer
-            print(f'{len(preds)=} for {tgt=}')
+            # print(f'{len(preds)=} for {tgt=}')
 
             # If any predecessor is a tree edge, the others need gotos.
             # If none are tree edges, one will be chosen arbitrarily
@@ -364,21 +363,22 @@ class LoopAnalysis:
             for p in sorted(preds): # inner
                 edge = (p, tgt)
                 if rg.edge_flavor(p, tgt) == 'tree':
-                    print(f'tree {edge=} cannot be a goto')
+                    # print(f'tree {edge=} cannot be a goto')
                     continue
                 if rg.edge_flavor(p, tgt) == 'back':
                     if loop_scope_for_node_is(p, tgt, inscope):
-                        print(f"      skipping {edge=} because the pred is in the scope of the target")
+                        # print(f"      skipping {edge=} because the pred is in the scope of the target")
                         continue # to inner
                     else:
-                        print(f"  not skipping {edge=} because the pred is not in the scope of the target")
+                        pass
+                        # print(f"  not skipping {edge=} because the pred is not in the scope of the target")
                 if not exempted_one_pred:
                     exempted_one_pred = True
-                    print(f"     exempting {edge=} from gotos because it was the first leading to the target")
+                    # print(f"     exempting {edge=} from gotos because it was the first leading to the target")
                 else:
-                    print(f"     adding goto {edge=}")
+                    # print(f"     adding goto {edge=}")
                     gotoedges.add(edge)
-        print(f"######## eventually got {gotoedges=}")
+        # print(f"######## eventually got {gotoedges=}")
         return gotoedges
 
     def compute_breakedges(gotoedges: Set[Tuple[str, str]],
@@ -392,7 +392,7 @@ class LoopAnalysis:
         # targeting it.
         for hdr in loopheaders:
             pdom = afterloop[hdr]
-            print(f"::break target for {hdr=} is {pdom=} {inscope[pdom] if pdom in inscope else None}")
+            # print(f"::break target for {hdr=} is {pdom=} {inscope[pdom] if pdom in inscope else None}")
             for src in rg.edges:
                 if pdom not in rg.edges[src]:
                     continue
@@ -400,10 +400,10 @@ class LoopAnalysis:
                     src_outside_hdr = src in inscope and inscope[src][0] != hdr
                     owned_elsewhere = pdom in owners and owners[pdom][0] != hdr
                     if (not owned_elsewhere) and not src_outside_hdr:
-                        print(f"::::adding break edge owned by {hdr=} : {(src,pdom)=}")
+                        # print(f"::::adding break edge owned by {hdr=} : {(src,pdom)=}")
                         breakedges.add( (src, pdom) )
                     else:
-                        print(f"::::adding goto edge owned by {hdr=} : {(src,pdom)=} ;; {owned_elsewhere=} {src_outside_hdr=}")
+                        # print(f"::::adding goto edge owned by {hdr=} : {(src,pdom)=} ;; {owned_elsewhere=} {src_outside_hdr=}")
                         gotoedges.add( (src, pdom) )
         return breakedges
 
@@ -441,7 +441,6 @@ class LoopAnalysis:
 
                 if succ in afterloop.values():
                     process(succ, depth, afterloop, 'loop')
-                    #process(succ, depth, afterloop, 'cond')
                     continue
 
                 newdepth = depth
@@ -457,12 +456,12 @@ class LoopAnalysis:
                 #print(f"exploring {succ=} via {node=} with depth {newdepth}")
                 worklist.append((succ, newdepth))
 
-        import pprint
-        print("scope nesting depths:")
-        pprint.pprint(depths, indent=4)
+        # import pprint
+        # print("scope nesting depths:")
+        # pprint.pprint(depths, indent=4)
 
-        print("owners:")
-        pprint.pprint(owners, indent=4)
+        # print("owners:")
+        # pprint.pprint(owners, indent=4)
         return owners
 
 class Cfg:
@@ -559,50 +558,14 @@ class Cfg:
             fn: "Function",
             astree: ASTInterface,
             blockstmts: Dict[str, AST.ASTStmt]) -> AST.ASTNode:
-        
-        self.derived_graph_sequence.to_dot("/home/ben/", "nustmtast")
-        for id in blockstmts.keys():
-            from chb.ast.ASTCPrettyPrinter import ASTCPrettyPrinter
-            pp = ASTCPrettyPrinter(astree.astree.symboltable)
-            pp.stmt_to_c(blockstmts[id])
-            sep = "\n     "
-            c = sep.join(str(pp.ccode).split("\n"))
-            print(f'{id} ==>{sep}{c}')
 
         la = LoopAnalysis(self.derived_graph_sequence)
-        inscope, all_backedges, loopsignatures, loopfollows, afterloop, ipostdoms = la.analyze_loops(self.flowgraph)
+        inscope, all_backedges, loopsignatures, _loopfollows, afterloop, _ipostdoms = \
+                    la.analyze_loops(self.flowgraph)
         
-        idoms = self.flowgraph.idoms
-
-
-        import pprint
-        print(f"inscope:")
-        pprint.pprint(inscope, indent=4)
-
-        print(f"loopsignatures:")
-        pprint.pprint(loopsignatures, indent=4)
-
-
-        print("idoms:")
-        pprint.pprint(idoms, indent=4)
-
-        print("ipostdoms:")
-        pprint.pprint(ipostdoms, indent=4)
-
-        pprint.pprint(self.flowgraph._edge_flavors, indent=4)
-
-        print(f'loopfollows:')
-        pprint.pprint(loopfollows, indent=4)
-        print(f'afterloop:')
-        pprint.pprint(afterloop, indent=4)
-
         loopheaders = set(sig[0] for sig in loopsignatures)
         latchingnodes = set(src for src, tgt in all_backedges)
-        print(f'{loopheaders=} ; {latchingnodes=} (ndet ok)')
         twowayconds = self.flowgraph.two_way_conditionals(latchingnodes)
-
-        print(f'twowayconds:')
-        pprint.pprint(twowayconds, indent=4)
 
         gotoedges = LoopAnalysis.compute_gotoedges(self.flowgraph, twowayconds, inscope)
         non_goto_backedges = all_backedges - gotoedges
@@ -615,6 +578,7 @@ class Cfg:
         
         # mutates gotoedges
         breakedges = LoopAnalysis.compute_breakedges(gotoedges, self.flowgraph, loopheaders, afterloop, inscope, owners)
+
 
         def emit(n: str) -> List[AST.ASTStmt]:
             """Produces the AST for a block, preceded by a label (which may not get printed)."""
@@ -632,14 +596,14 @@ class Cfg:
             # When processing the two arms of a conditional branch,
             # `follow` indicates the join point, i.e. where the arms end.
 
-            print(f"construct({n=}, {follow=}, {loopheader=})")
+            #print(f"construct({n=}, {follow=}, {loopheader=})")
 
             if follow and n == follow:
-                print(f"stopping at {follow=} and returning what's been collected so far")
+                #print(f"stopping at {follow=} and returning what's been collected so far")
                 return astree.mk_block(result)
 
             if n in constructed_stmts:
-                print(f"###########################  already constructed {n=}; emitting an unexpected goto")
+                #print(f"###########################  already constructed {n=}; emitting an unexpected goto")
                 labeled_stmts[n]._printed = True
                 return astree.mk_block(result + [astree.mk_goto_stmt(n)])
             else:
@@ -652,8 +616,8 @@ class Cfg:
                 # When we encounter a loop header for the first time, we recur with
                 # a new `loopheader` flag so that we don't infinitely recurse.
                 follownode = afterloop[n]
-                print(f"LOOP LOOP LOOP LOOP LOOP encountered loop header node {n=}, {len(result)=}")
-                print(f'                {follownode=} ; {loopheader=} ; {follow=} ; {owners=}')
+                # print(f"LOOP LOOP LOOP LOOP LOOP encountered loop header node {n=}, {len(result)=}")
+                # print(f'                {follownode=} ; {loopheader=} ; {follow=} ; {owners=}')
                 constructed_stmts.remove(n)
                 body = construct(n, follow, n, [])
                 loop = astree.mk_loop(body)
@@ -720,10 +684,10 @@ class Cfg:
                 if (not follownode \
                         or (n == loopheader and afterloop[loopheader] == follownode) \
                         or (follownode in owners and owners[follownode] != (n, 'cond'))):
-                    print(f',,,,,, skipping continuation of 2-succ node {n=} {loopheader=} {follownode=} {follow=}')
+                    # print(f',,,,,, skipping continuation of 2-succ node {n=} {loopheader=} {follownode=} {follow=}')
                     return astree.mk_block(result + emit(n) + [bstmt])
 
-                print(f',,,,,, constructing continuation of 2-succ node {n=} {loopheader=} {follownode=} {follow=}')
+                # print(f',,,,,, constructing continuation of 2-succ node {n=} {loopheader=} {follownode=} {follow=}')
                 return construct(
                     follownode, follow, loopheader, result + emit(n) + [bstmt])
             else:

--- a/chb/app/DerivedGraphSequence.py
+++ b/chb/app/DerivedGraphSequence.py
@@ -421,7 +421,7 @@ class DerivedGraphSequence:
         """Return hierarchical reverse postorder on all nodes."""
 
         prevrpo: Dict[str, List[int]] = {}
-        if self.graphs[-1].size == 1:
+        if self.is_reducible:
             header = self.graphs[-1].nodes[0]
             prevrpo = {header: [0]}
             for g in self.graphs[:-1][::-1]:
@@ -445,12 +445,11 @@ class DerivedGraphSequence:
             self._graphs.append(g)
 
     def to_dot(self, path: str, out: str):
-        rpo = self.graphs[-1].size == 1
         for (i, g) in enumerate(self.graphs):
             pdffilename = UD.print_dot(
                 path,
                 out + str(i+1),
-                g.to_dot("G" + str(i+1), rpo=self.hrpo, showintervals=True))
+                g.to_dot("G" + str(i+1), rpo=self.hrpo, showintervals=self.is_reducible))
             print(pdffilename)
 
     def __str__(self) -> str:

--- a/chb/ast/ASTByteSizeCalculator.py
+++ b/chb/ast/ASTByteSizeCalculator.py
@@ -127,7 +127,19 @@ class ASTByteSizeCalculator(ASTIndexer):
     def index_return_stmt(self, stmt: AST.ASTReturn) -> int:
         return 0
 
+    def index_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> int:
+        return 0
+
+    def index_goto_stmt(self, stmt: AST.ASTGoto) -> int:
+        return 0
+
+    def index_label_stmt(self, stmt: AST.ASTLabel) -> int:
+        return 0
+
     def index_block_stmt(self, stmt: AST.ASTBlock) -> int:
+        return 0
+
+    def index_loop_stmt(self, stmt: AST.ASTLoop) -> int:
         return 0
 
     def index_branch_stmt(self, stmt: AST.ASTBranch) -> int:

--- a/chb/ast/ASTCPrettyPrinter.py
+++ b/chb/ast/ASTCPrettyPrinter.py
@@ -232,8 +232,9 @@ class ASTCPrettyPrinter(ASTVisitor):
         self.ccode.write("goto " + stmt._label + ";")
 
     def visit_label_stmt(self, stmt: AST.ASTLabel) -> None:
-        self.ccode.newline(indent=self.indent)
-        self.ccode.write(stmt._label + ":")
+        if stmt._printed:
+            self.ccode.newline(indent=self.indent)
+            self.ccode.write(stmt._label + ":")
 
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
         for s in stmt.stmts:

--- a/chb/ast/ASTCPrettyPrinter.py
+++ b/chb/ast/ASTCPrettyPrinter.py
@@ -232,9 +232,8 @@ class ASTCPrettyPrinter(ASTVisitor):
         self.ccode.write("goto " + stmt._label + ";")
 
     def visit_label_stmt(self, stmt: AST.ASTLabel) -> None:
-        if stmt._printed:
-            self.ccode.newline(indent=self.indent)
-            self.ccode.write(stmt._label + ":")
+        self.ccode.newline(indent=self.indent)
+        self.ccode.write(stmt._label + ":")
 
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
         for s in stmt.stmts:

--- a/chb/ast/ASTCTyper.py
+++ b/chb/ast/ASTCTyper.py
@@ -41,7 +41,19 @@ class ASTCTyper(ABC):
     def ctype_return_stmt(self, stmt: AST.ASTReturn) -> Optional[AST.ASTTyp]:
         return None
 
+    def ctype_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> Optional[AST.ASTTyp]:
+        return None
+
+    def ctype_goto_stmt(self, stmt: AST.ASTGoto) -> Optional[AST.ASTTyp]:
+        return None
+
+    def ctype_label_stmt(self, stmt: AST.ASTLabel) -> Optional[AST.ASTTyp]:
+        return None
+
     def ctype_block_stmt(self, stmt: AST.ASTBlock) -> Optional[AST.ASTTyp]:
+        return None
+
+    def ctype_loop_stmt(self, stmt: AST.ASTLoop) -> Optional[AST.ASTTyp]:
         return None
 
     def ctype_instruction_sequence_stmt(

--- a/chb/ast/ASTIndexer.py
+++ b/chb/ast/ASTIndexer.py
@@ -41,7 +41,23 @@ class ASTIndexer(ABC):
         ...
 
     @abstractmethod
+    def index_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> int:
+        ...
+
+    @abstractmethod
+    def index_goto_stmt(self, stmt: AST.ASTGoto) -> int:
+        ...
+
+    @abstractmethod
+    def index_label_stmt(self, stmt: AST.ASTLabel) -> int:
+        ...
+
+    @abstractmethod
     def index_block_stmt(self, stmt: AST.ASTBlock) -> int:
+        ...
+
+    @abstractmethod
+    def index_loop_stmt(self, stmt: AST.ASTLoop) -> int:
         ...
 
     @abstractmethod

--- a/chb/ast/ASTLiveCode.py
+++ b/chb/ast/ASTLiveCode.py
@@ -88,7 +88,28 @@ class ASTLiveCode(ASTNOPVisitor):
             self.set_live_x(set([]))
         self._livestmts.add(stmt.assembly_xref)
 
+    def visit_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> None:
+        self.set_live_on_exit(stmt.assembly_xref, self.live_x)
+        self._livestmts.add(stmt.assembly_xref)
+
+    def visit_goto_stmt(self, stmt: AST.ASTGoto) -> None:
+        # TODO???
+        self.set_live_on_exit(stmt.assembly_xref, self.live_x)
+        self._livestmts.add(stmt.assembly_xref)
+
+    def visit_label_stmt(self, stmt: AST.ASTLabel) -> None:
+        self.set_live_on_exit(stmt.assembly_xref, self.live_x)
+        self._livestmts.add(stmt.assembly_xref)
+
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
+        self.set_live_on_exit(stmt.assembly_xref, self.live_x)
+        for s in reversed(stmt.stmts):
+            s.accept(self)
+        self._livestmts.add(stmt.assembly_xref)
+
+
+    def visit_loop_stmt(self, stmt: AST.ASTLoop) -> None:
+        # TODO(brk): any differences for loop versus block?
         self.set_live_on_exit(stmt.assembly_xref, self.live_x)
         for s in reversed(stmt.stmts):
             s.accept(self)

--- a/chb/ast/ASTNOPVisitor.py
+++ b/chb/ast/ASTNOPVisitor.py
@@ -38,7 +38,19 @@ class ASTNOPVisitor(ASTVisitor):
     def visit_return_stmt(self, stmt: AST.ASTReturn) -> None:
         pass
 
+    def visit_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> None:
+        pass
+
+    def visit_goto_stmt(self, stmt: AST.ASTGoto) -> None:
+        pass
+
+    def visit_label_stmt(self, stmt: AST.ASTLabel) -> None:
+        pass
+
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
+        pass
+
+    def visit_loop_stmt(self, stmt: AST.ASTLoop) -> None:
         pass
 
     def visit_instruction_sequence_stmt(

--- a/chb/ast/ASTNode.py
+++ b/chb/ast/ASTNode.py
@@ -458,9 +458,10 @@ class ASTGoto(ASTStmt):
 
 class ASTLabel(ASTStmt):
 
-    def __init__(self, assembly_xref: int, label: str) -> None:
+    def __init__(self, assembly_xref: int, label: str, printed: bool) -> None:
         ASTStmt.__init__(self, assembly_xref, "label")
         self._label = label
+        self._printed = printed
 
     @property
     def is_ast_label(self) -> bool:

--- a/chb/ast/ASTNode.py
+++ b/chb/ast/ASTNode.py
@@ -458,10 +458,9 @@ class ASTGoto(ASTStmt):
 
 class ASTLabel(ASTStmt):
 
-    def __init__(self, assembly_xref: int, label: str, printed: bool) -> None:
+    def __init__(self, assembly_xref: int, label: str) -> None:
         ASTStmt.__init__(self, assembly_xref, "label")
         self._label = label
-        self._printed = printed
 
     @property
     def is_ast_label(self) -> bool:

--- a/chb/ast/ASTSerializer.py
+++ b/chb/ast/ASTSerializer.py
@@ -352,6 +352,8 @@ class ASTSerializer(ASTIndexer):
         return self.add(tags, args, node)
 
     def index_label_stmt(self, stmt: AST.ASTLabel) -> int:
+        if not stmt._printed:
+            return None # ehh
         tags: List[str] = [stmt.tag, str(stmt.assembly_xref)]
         args: List[int] = []
         node: Dict[str, Any] = {"tag": stmt.tag}
@@ -390,6 +392,7 @@ class ASTSerializer(ASTIndexer):
         args: List[int] = [instr.index(self) for instr in stmt.instructions]
         node: Dict[str, Any] = {"tag": stmt.tag}
         node["assembly-xref"] = stmt.assembly_xref
+        args = [x for x in args if x is not None]
         return self.add(tags, args, node)
 
     def index_assign_instr(self, instr: AST.ASTAssign) -> int:

--- a/chb/ast/ASTSerializer.py
+++ b/chb/ast/ASTSerializer.py
@@ -352,8 +352,6 @@ class ASTSerializer(ASTIndexer):
         return self.add(tags, args, node)
 
     def index_label_stmt(self, stmt: AST.ASTLabel) -> int:
-        if not stmt._printed:
-            return None # ehh
         tags: List[str] = [stmt.tag, str(stmt.assembly_xref)]
         args: List[int] = []
         node: Dict[str, Any] = {"tag": stmt.tag}

--- a/chb/ast/ASTSerializer.py
+++ b/chb/ast/ASTSerializer.py
@@ -300,8 +300,20 @@ class ASTSerializer(ASTIndexer):
         if stmt.is_ast_return:
             return self.index_return_stmt(cast(AST.ASTReturn, stmt))
 
+        elif stmt.is_ast_break or stmt.is_ast_continue:
+            return self.index_break_or_continue_stmt(cast(AST.ASTBreakOrContinue, stmt))
+
+        elif stmt.is_ast_goto:
+            return self.index_goto_stmt(cast(AST.ASTGoto, stmt))
+
+        elif stmt.is_ast_label:
+            return self.index_label_stmt(cast(AST.ASTLabel, stmt))
+
         elif stmt.is_ast_block:
             return self.index_block_stmt(cast(AST.ASTBlock, stmt))
+
+        elif stmt.is_ast_loop:
+            return self.index_loop_stmt(cast(AST.ASTLoop, stmt))
 
         elif stmt.is_ast_instruction_sequence:
             return self.index_instruction_sequence_stmt(
@@ -324,7 +336,37 @@ class ASTSerializer(ASTIndexer):
             args.append(-1)
         return self.add(tags, args, node)
 
+    def index_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> int:
+        tags: List[str] = [stmt.tag, str(stmt.assembly_xref)]
+        args: List[int] = []
+        node: Dict[str, Any] = {"tag": stmt.tag}
+        node["assembly-xref"] = stmt.assembly_xref
+        return self.add(tags, args, node)
+
+    def index_goto_stmt(self, stmt: AST.ASTGoto) -> int:
+        tags: List[str] = [stmt.tag, str(stmt.assembly_xref)]
+        args: List[int] = []
+        node: Dict[str, Any] = {"tag": stmt.tag}
+        node["assembly-xref"] = stmt.assembly_xref
+        node["label"] = stmt._label
+        return self.add(tags, args, node)
+
+    def index_label_stmt(self, stmt: AST.ASTLabel) -> int:
+        tags: List[str] = [stmt.tag, str(stmt.assembly_xref)]
+        args: List[int] = []
+        node: Dict[str, Any] = {"tag": stmt.tag}
+        node["assembly-xref"] = stmt.assembly_xref
+        node["label"] = stmt._label
+        return self.add(tags, args, node)
+
     def index_block_stmt(self, stmt: AST.ASTBlock) -> int:
+        tags: List[str] = [stmt.tag, str(stmt.assembly_xref)]
+        args: List[int] = [s.index(self) for s in stmt.stmts]
+        node: Dict[str, Any] = {"tag": stmt.tag}
+        node["assembly-xref"] = stmt.assembly_xref
+        return self.add(tags, args, node)
+
+    def index_loop_stmt(self, stmt: AST.ASTBlock) -> int:
         tags: List[str] = [stmt.tag, str(stmt.assembly_xref)]
         args: List[int] = [s.index(self) for s in stmt.stmts]
         node: Dict[str, Any] = {"tag": stmt.tag}

--- a/chb/ast/ASTTransformer.py
+++ b/chb/ast/ASTTransformer.py
@@ -41,7 +41,23 @@ class ASTTransformer(ABC):
         ...
 
     @abstractmethod
+    def transform_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> AST.ASTStmt:
+        ...
+
+    @abstractmethod
+    def transform_goto_stmt(self, stmt: AST.ASTGoto) -> AST.ASTStmt:
+        ...
+
+    @abstractmethod
+    def transform_label_stmt(self, stmt: AST.ASTLabel) -> AST.ASTStmt:
+        ...
+
+    @abstractmethod
     def transform_block_stmt(self, stmt: AST.ASTBlock) -> AST.ASTStmt:
+        ...
+
+    @abstractmethod
+    def transform_loop_stmt(self, stmt: AST.ASTLoop) -> AST.ASTStmt:
         ...
 
     @abstractmethod

--- a/chb/ast/ASTVisitor.py
+++ b/chb/ast/ASTVisitor.py
@@ -42,7 +42,23 @@ class ASTVisitor(ABC):
         ...
 
     @abstractmethod
+    def visit_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> None:
+        ...
+
+    @abstractmethod
+    def visit_goto_stmt(self, stmt: AST.ASTGoto) -> None:
+        ...
+
+    @abstractmethod
+    def visit_label_stmt(self, stmt: AST.ASTLabel) -> None:
+        ...
+
+    @abstractmethod
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
+        ...
+
+    @abstractmethod
+    def visit_loop_stmt(self, stmt: AST.ASTLoop) -> None:
         ...
 
     @abstractmethod

--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -192,11 +192,10 @@ class AbstractSyntaxTree:
     def mk_label_stmt(
             self,
             label: str,
-            printed: bool = False,
             opt_assembly_xref: Optional[int] = None) -> AST.ASTBreakOrContinue:
         assembly_xref = (
             self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
-        return AST.ASTLabel(assembly_xref, label, printed)
+        return AST.ASTLabel(assembly_xref, label)
 
     def mk_return_stmt(
             self,

--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -159,6 +159,37 @@ class AbstractSyntaxTree:
             self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
         return AST.ASTBlock(assembly_xref, stmts)
 
+    def mk_loop(
+            self,
+            body: AST.ASTStmt,
+            opt_assembly_xref: Optional[int] = None) -> AST.ASTLoop:
+        assembly_xref = (
+            self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
+        return AST.ASTLoop(assembly_xref, body)
+
+    def mk_break_stmt(
+            self,
+            opt_assembly_xref: Optional[int] = None) -> AST.ASTBreakOrContinue:
+        assembly_xref = (
+            self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
+        return AST.ASTBreakOrContinue(assembly_xref, "break")
+
+    def mk_goto_stmt(
+            self,
+            label: str,
+            opt_assembly_xref: Optional[int] = None) -> AST.ASTBreakOrContinue:
+        assembly_xref = (
+            self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
+        return AST.ASTGoto(assembly_xref, label)
+
+    def mk_label_stmt(
+            self,
+            label: str,
+            opt_assembly_xref: Optional[int] = None) -> AST.ASTBreakOrContinue:
+        assembly_xref = (
+            self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
+        return AST.ASTLabel(assembly_xref, label)
+
     def mk_return_stmt(
             self,
             expr: Optional[AST.ASTExpr],

--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -174,6 +174,13 @@ class AbstractSyntaxTree:
             self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
         return AST.ASTBreakOrContinue(assembly_xref, "break")
 
+    def mk_continue_stmt(
+            self,
+            opt_assembly_xref: Optional[int] = None) -> AST.ASTBreakOrContinue:
+        assembly_xref = (
+            self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
+        return AST.ASTBreakOrContinue(assembly_xref, "continue")
+
     def mk_goto_stmt(
             self,
             label: str,
@@ -185,10 +192,11 @@ class AbstractSyntaxTree:
     def mk_label_stmt(
             self,
             label: str,
+            printed: bool = False,
             opt_assembly_xref: Optional[int] = None) -> AST.ASTBreakOrContinue:
         assembly_xref = (
             self.new_xref() if opt_assembly_xref is None else opt_assembly_xref)
-        return AST.ASTLabel(assembly_xref, label)
+        return AST.ASTLabel(assembly_xref, label, printed)
 
     def mk_return_stmt(
             self,

--- a/chb/astinterface/ASTInterface.py
+++ b/chb/astinterface/ASTInterface.py
@@ -33,10 +33,12 @@ from typing import (
     Callable,
     cast,
     Dict,
+    Iterable,
     List,
     Mapping,
     NewType,
     Optional,
+    Set,
     Sequence,
     Tuple,
     TYPE_CHECKING,
@@ -369,8 +371,20 @@ class ASTInterface:
     def mk_block(self, stmts: List[AST.ASTStmt]) -> AST.ASTBlock:
         return self.astree.mk_block(stmts)
 
+    def mk_loop(self, body: AST.ASTStmt) -> AST.ASTLoop:
+        return self.astree.mk_loop(body)
+
     def mk_return_stmt(self, expr: Optional[AST.ASTExpr]) -> AST.ASTReturn:
         return self.astree.mk_return_stmt(expr)
+
+    def mk_break_stmt(self) -> AST.ASTBreakOrContinue:
+        return self.astree.mk_break_stmt()
+
+    def mk_goto_stmt(self, label: str) -> AST.ASTGoto:
+        return self.astree.mk_goto_stmt(label)
+
+    def mk_label_stmt(self, label: str) -> AST.ASTLabel:
+        return self.astree.mk_label_stmt(label)
 
     def mk_branch(
             self,

--- a/chb/astinterface/ASTInterface.py
+++ b/chb/astinterface/ASTInterface.py
@@ -380,6 +380,9 @@ class ASTInterface:
     def mk_break_stmt(self) -> AST.ASTBreakOrContinue:
         return self.astree.mk_break_stmt()
 
+    def mk_continue_stmt(self) -> AST.ASTBreakOrContinue:
+        return self.astree.mk_continue_stmt()
+
     def mk_goto_stmt(self, label: str) -> AST.ASTGoto:
         return self.astree.mk_goto_stmt(label)
 

--- a/chb/astinterface/ASTRewriter.py
+++ b/chb/astinterface/ASTRewriter.py
@@ -70,8 +70,20 @@ class ASTRewriter(ASTTransformer):
         if stmt.is_ast_return:
             return self.transform_return_stmt(cast(AST.ASTReturn, stmt))
 
+        elif stmt.is_ast_break or stmt.is_ast_continue:
+            return self.transform_break_or_continue_stmt(cast(AST.ASTBreakOrContinue, stmt))
+
+        elif stmt.is_ast_goto:
+            return self.transform_goto_stmt(cast(AST.ASTGoto, stmt))
+
+        elif stmt.is_ast_label:
+            return self.transform_label_stmt(cast(AST.ASTLabel, stmt))
+
         elif stmt.is_ast_block:
             return self.transform_block_stmt(cast(AST.ASTBlock, stmt))
+
+        elif stmt.is_ast_loop:
+            return self.transform_loop_stmt(cast(AST.ASTLoop, stmt))
 
         elif stmt.is_ast_instruction_sequence:
             return self.transform_instruction_sequence_stmt(
@@ -90,10 +102,27 @@ class ASTRewriter(ASTTransformer):
         else:
             return stmt
 
+    def transform_break_or_continue_stmt(self, stmt: AST.ASTBreakOrContinue) -> AST.ASTStmt:
+        self.set_currentid(stmt.assembly_xref)
+        return stmt
+
+    def transform_goto_stmt(self, stmt: AST.ASTGoto) -> AST.ASTStmt:
+        self.set_currentid(stmt.assembly_xref)
+        return stmt
+
+    def transform_label_stmt(self, stmt: AST.ASTLabel) -> AST.ASTStmt:
+        self.set_currentid(stmt.assembly_xref)
+        return stmt
+
     def transform_block_stmt(self, stmt: AST.ASTBlock) -> AST.ASTStmt:
         self.set_currentid(stmt.assembly_xref)
         return AST.ASTBlock(
             stmt.assembly_xref, [s.transform(self) for s in stmt.stmts])
+
+    def transform_loop_stmt(self, stmt: AST.ASTLoop) -> AST.ASTStmt:
+        self.set_currentid(stmt.assembly_xref)
+        return AST.ASTLoop(
+            stmt.assembly_xref, stmt.stmts[0].transform(self))
 
     def transform_instruction_sequence_stmt(
             self, stmt: AST.ASTInstrSequence) -> AST.ASTStmt:

--- a/chb/util/tingly.py
+++ b/chb/util/tingly.py
@@ -38,7 +38,8 @@ class RootedDiGraph:
             starttime[node] = vtime
             vtime += 1
 
-            successors = self.post(node)
+            # Set iteration order is nondeterministic, so we must sort to ensure determinism.
+            successors = sorted(self.post(node))
             if len(prev_rpo) > 0:
                 succ_idxs = sorted(prev_rpo.index(x) for x in successors)
                 successors = [prev_rpo[i] for i in succ_idxs]
@@ -271,7 +272,7 @@ class RootedDiGraph:
                     if follow is not None:
                         self._twowayconditionals[m] = follow
                         toberemoved: List[str] = []
-                        for k in unresolved:
+                        for k in sorted(unresolved):
                             if is_descendant(follow, k):
                                 print(f"   _twowayconditionals updating {k=} as descendent to have {follow=} from {m=}")
                                 self._twowayconditionals[k] = follow

--- a/chb/util/tingly.py
+++ b/chb/util/tingly.py
@@ -139,8 +139,8 @@ class RootedDiGraph:
         Computes the dominators of each node.
 
         Implements the algorithm in:
-            Cristina Cifuentes, Structuring Decompiled Graphs, Compiler Construction,
-            CC'96, LNCS 1060, pg 91-105, Springer, 1996.
+            "A Simple, Fast Dominance Algorithm"
+            Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy
             https://www.cs.rice.edu/~keith/EMBED/dom.pdf
         """
 

--- a/chb/util/tingly.py
+++ b/chb/util/tingly.py
@@ -16,7 +16,7 @@ class RootedDiGraph:
         self._revedges: Dict[str, List[str]] = {}
         self._twowayconditionals: Dict[str, str] = {} # follow nodes
         self._idoms: Dict[UserNodeID, Optional[UserNodeID]] = {n:None for n in nodes} # immediate dominator
-        
+
         self._compute_dfs() # First DFS computes the reverse postorder list.
         self._compute_dfs() # DFS in RPO order can produce fewer cross edges.
         self._compute_doms()
@@ -120,22 +120,9 @@ class RootedDiGraph:
         return RootedDiGraph(self.nodes + [phantomend], augedges, phantomend)
 
     def ipostdoms(rrg: 'RootedDiGraph') -> Dict[UserNodeID, Set[UserNodeID]]:
-        if True:
-            import chb.util.dotutil as UD
-            from chb.util.DotGraph import DotGraph
-
-            dotgraph = DotGraph("rrg")
-            for n in rrg.nodes:
-                dotgraph.add_node(n, labeltxt=str(n))
-
-            for src in rrg.edges:
-                for tgt in rrg.edges[src]:
-                    dotgraph.add_edge(src, tgt)
-
-            UD.print_dot("/home/ben/", "rrg", dotgraph)
-        #print(rrg.nodes)
-        #print(rrg.edges)
-        idoms = rrg.idoms
+        idoms = dict(rrg.idoms)
+        # The start node of the reverse graph is a phantom node that doesn't
+        # exist in the original graph.
         del idoms[rrg.start_node]
         return idoms
             

--- a/chb/util/tingly.py
+++ b/chb/util/tingly.py
@@ -186,7 +186,7 @@ class RootedDiGraph:
 
     def idom(self, node: UserNodeID) -> Optional[UserNodeID]:
         """
-        Returns the immediate dominator of node.
+        Returns the immediate dominator of the given node.
         """
         return self._idoms[node]
 
@@ -264,8 +264,10 @@ class RootedDiGraph:
 
         if len(self._twowayconditionals) == 0:
             for m in reversed(self._rpo_sorted):
+                # Cifuentes skips nodes marked as loop headers, since she integrates
+                # the conditional directly into the loop construct, but we keep them
+                # separate, and so do not skip loop headers.
                 if (    len(self.post(m)) == 2   # 2-way conditional
-                        #and not m in loopheaders  # not a loop header
                         and not m in latchingnodes):  # not a latching node
                     follow = find_follow(m)
                     print(f"   _twowayconditionals:     {m=} {follow=}")

--- a/chb/util/tingly.py
+++ b/chb/util/tingly.py
@@ -257,13 +257,13 @@ class RootedDiGraph:
                 if (    len(self.post(m)) == 2   # 2-way conditional
                         and not m in latchingnodes):  # not a latching node
                     follow = find_follow(m)
-                    print(f"   _twowayconditionals:     {m=} {follow=}")
+                    # print(f"   _twowayconditionals:     {m=} {follow=}")
                     if follow is not None:
                         self._twowayconditionals[m] = follow
                         toberemoved: List[str] = []
                         for k in sorted(unresolved):
                             if is_descendant(follow, k):
-                                print(f"   _twowayconditionals updating {k=} as descendent to have {follow=} from {m=}")
+                                # print(f"   _twowayconditionals updating {k=} as descendent to have {follow=} from {m=}")
                                 self._twowayconditionals[k] = follow
                                 toberemoved.append(k)
                         for k in toberemoved:

--- a/chb/util/tingly.py
+++ b/chb/util/tingly.py
@@ -1,0 +1,253 @@
+# tingly, the TINy Graph LibrarY
+
+from typing import Dict, List, Mapping, Optional, Sequence, Set, Tuple
+
+UserNodeID = str # or int, whatever
+
+class RootedDiGraph:
+
+    def __init__(self, nodes: Sequence[UserNodeID], edges: Mapping[UserNodeID, Sequence[UserNodeID]], start_node: UserNodeID):
+        self.nodes = nodes
+        self.edges = edges
+        self.start_node = start_node
+        self._rpo: Dict[UserNodeID, int] = {}
+        self._rpo_sorted: List[UserNodeID] = []
+        self._edge_flavors: Dict[Tuple[UserNodeID, UserNodeID], str] = {}
+        self._revedges: Dict[str, List[str]] = {}
+        self._twowayconditionals: Dict[str, str] = {} # follow nodes
+        self._idoms: Dict[UserNodeID, Optional[UserNodeID]] = {n:None for n in nodes} # immediate dominator
+        
+        self._compute_dfs()
+        self._compute_doms()
+
+    def _compute_dfs(self) -> None:
+        visited = set()
+        starttime = {v:0 for v in self.nodes}
+        endtime = {v:0 for v in self.nodes}
+        vtime = 0
+
+        def visit(node: str) -> None:
+            nonlocal vtime
+            visited.add(node)
+            starttime[node] = vtime
+            vtime += 1
+
+            for t in self.post(node):
+                if t not in visited:
+                    self._edge_flavors[(node, t)] = "tree"
+                    visit(t)
+                else:
+                    if endtime[t] == 0: # starttime[t] < starttime[node] and endtime[t] > endtime[node]:
+                        self._edge_flavors[(node, t)] = "back"
+                    elif starttime[t] > starttime[node]: # and endtime[t] < endtime[node]:
+                        self._edge_flavors[(node, t)] = "forward"
+                    else: # starttime[t] < starttime[node] and endtime[t] < endtime[node]:
+                        self._edge_flavors[(node, t)] = "cross"
+            
+            endtime[node] = vtime
+            vtime += 1
+
+            self._rpo_sorted.append(node)
+
+        visit(self.start_node)
+        self._rpo_sorted.reverse()
+
+    def edge_flavor(self, src: UserNodeID, tgt: UserNodeID) -> str:
+        """
+        Returns the flavor of the edge ('back', 'forward', 'cross', 'tree') from src to tgt.
+        """
+        return self._edge_flavors[(src, tgt)]
+
+    @property
+    def revedges(self) -> Dict[str, List[str]]:
+        if len(self._revedges) == 0:
+            for src in self.edges:
+                for tgt in self.edges[src]:
+                    self._revedges.setdefault(tgt, [])
+                    self._revedges[tgt].append(src)
+        return self._revedges
+
+    @property
+    def rpo_sorted(self) -> List[UserNodeID]:
+        """
+        Returns a list of the graph's nodes in a reverse postorder.
+        """
+        return self._rpo_sorted
+
+    @property
+    def rpo(self) -> Dict[UserNodeID, int]:
+        """
+        Returns a mapping from address to index in the reverse postorder.
+        """
+        if len(self._rpo) == 0:
+            self._rpo = {k:i+1 for i, k in enumerate(self.rpo_sorted)}
+        return self._rpo
+
+    def post(self, n) -> Set[str]:
+        if n in self.edges:
+            return set(self.edges[n])
+        else:
+            return set([])
+
+    def pre(self, n) -> Set[str]:
+        if n in self.revedges:
+            return set(self.revedges[n])
+        else:
+            return set([])
+
+    def ipostdoms(self):
+        phantomend = '__' + str(len(self.nodes))
+        augedges = self.revedges.copy()
+        terminators = [node for node in self.nodes if len(self.post(node)) == 0]
+        augedges[phantomend] = terminators
+        rrg = RootedDiGraph(self.nodes + [phantomend], augedges, phantomend)
+
+        if True:
+            import chb.util.dotutil as UD
+            from chb.util.DotGraph import DotGraph
+
+            dotgraph = DotGraph("rrg")
+            for n in rrg.nodes:
+                dotgraph.add_node(n, labeltxt=str(n))
+
+            for src in rrg.edges:
+                for tgt in rrg.edges[src]:
+                    dotgraph.add_edge(src, tgt)
+
+            UD.print_dot("/home/ben/", "rrg", dotgraph)
+        #print(rrg.nodes)
+        #print(rrg.edges)
+        idoms = rrg.idoms
+        del idoms[phantomend]
+        return idoms
+            
+    def _compute_doms(self) -> None:
+        """
+        Computes the dominators of each node.
+
+        Implements the algorithm in:
+            Cristina Cifuentes, Structuring Decompiled Graphs, Compiler Construction,
+            CC'96, LNCS 1060, pg 91-105, Springer, 1996.
+            https://www.cs.rice.edu/~keith/EMBED/dom.pdf
+        """
+
+        def intersect(b1: UserNodeID, b2: UserNodeID) -> UserNodeID:
+            finger1 = b1
+            finger2 = b2
+            while finger1 != finger2:
+                # The paper describes comparisons on postorder numbers; we're using
+                # the reverse postorder numbers, so we need to flip the comparison.
+                while self.rpo[finger1] > self.rpo[finger2]:
+                    finger1 = self._idoms[finger1]
+                while self.rpo[finger2] > self.rpo[finger1]:
+                    finger2 = self._idoms[finger2]
+            return finger1
+
+        # Initialize the dominators of the start node to be the start node itself.
+        self._idoms[self.start_node] = self.start_node
+        changed = True
+        while changed:
+            changed = False
+            for node in self.rpo_sorted:
+                if node == self.start_node:
+                    continue
+                allpreds = list(self.pre(node))
+                new_idom = None
+                for pred in allpreds:
+                    if self._idoms[pred] is not None:
+                        new_idom = pred
+                        allpreds.remove(pred) # now it's almost-allpreds...
+                        break
+                assert new_idom is not None
+                for pred in allpreds:
+                    if self._idoms[pred] is not None:
+                        new_idom = intersect(pred, new_idom)
+                if self._idoms[node] != new_idom:
+                    self._idoms[node] = new_idom
+                    changed = True
+
+    def idom(self, node: UserNodeID) -> Optional[UserNodeID]:
+        """
+        Returns the immediate dominator of node.
+        """
+        return self._idoms[node]
+
+    @property
+    def idoms(self) -> Dict[UserNodeID, UserNodeID]:
+        """
+        Returns a mapping from node to its immediate dominator.
+        """
+        return self._idoms.copy()
+
+    # Linearly bounded by the depth of the dominator tree
+    def dominates(self, node_a: UserNodeID, node_b: UserNodeID) -> bool:
+        """
+        Returns True if node_a dominates node_b.
+        """
+        # Self-domination is implicit.
+        if node_a == node_b:
+            return True
+
+        finger = node_b
+        while finger != self.start_node:
+            if finger == node_a:
+                return True
+            finger = self._idoms[finger]
+        return False
+
+    
+    def two_way_conditionals(self, loopheaders: Set[str], latchingnodes: Set[str]) -> Dict[str, str]:
+        """Identify 2-way conditionals and their follow nodes.
+
+        Based on algorithm in:
+            Cristina Cifuentes, Structuring Decompiled Graphs, Compiler Construction,
+            CC'96, LNCS 1060, pg 91-105, Springer, 1996.
+            https://www.cs.rice.edu/~keith/EMBED/dom.pdf
+        """
+
+        def find_follow(m: str) -> Optional[str]:
+            followcandidates: List[str] = [
+                i for i in self.nodes
+                if self.idom(i) == m and len(self.pre(i)) >= 2]
+            if len(followcandidates) > 0:
+                return max(followcandidates, key=lambda k: self.rpo[k])
+            else:
+                return None
+
+        def is_descendant(child: str, parent: str) -> bool:
+            worklist = [child]
+            seen = set()
+            while worklist:
+                node = worklist.pop()
+                if node == parent:
+                    return True
+                if node in seen:
+                    continue
+                seen.add(node)
+                worklist.extend(self.pre(node))
+            return False
+
+        unresolved: Set[str] = set([])
+
+        if len(self._twowayconditionals) == 0:
+            for m in reversed(self._rpo_sorted):
+                if (    len(self.post(m)) == 2   # 2-way conditional
+                        and not m in loopheaders  # not a loop header
+                        and not m in latchingnodes):  # not a latching node
+                    follow = find_follow(m)
+                    print(f"        {follow=}")
+                    if follow is not None:
+                        self._twowayconditionals[m] = follow
+                        toberemoved: List[str] = []
+                        for k in unresolved:
+                            if is_descendant(follow, k):
+                                self._twowayconditionals[k] = follow
+                                toberemoved.append(k)
+                        for k in toberemoved:
+                            unresolved.remove(k)
+                    else:
+                        unresolved.add(m)
+
+        if len(unresolved) > 0:
+            print("Unresolved two-way conditional: " + ", ".join(unresolved))
+        return self._twowayconditionals

--- a/chb/util/tingly.py
+++ b/chb/util/tingly.py
@@ -200,7 +200,7 @@ class RootedDiGraph:
             finger = self._idoms[finger]
         return False
 
-    def two_way_conditionals(self, loopheaders: Set[str], latchingnodes: Set[str]) -> Dict[str, str]:
+    def two_way_conditionals(self, latchingnodes: Set[str]) -> Dict[str, str]:
         """Identify 2-way conditionals and their follow nodes.
 
         Based on algorithm in:


### PR DESCRIPTION
Henny,

This is in a reasonable state, I think, for review. If you merge it, it would probably make sense to collapse the merge into a single commit, since the commits here are somewhat haphazard in their progression. But I expect you'll want some changes made before merging.

A few notes:

* I created a separate class for a rooted directed graph. There's some overlap with Cfg and DerivedGraphSequence but with different assumptions. For example it re-implements dominators, but for the whole graph, not just within an interval. Computing postdominators via a reversed graph also seemed easier with a separate class. We'll probably want to come up with a less silly name than `tingly` for the module, though.
* The reverse postorders computed by DerivedGraphSequence and RootedDiGraph may not be the same, but I don't think the difference ought to matter. Cfg uses RootedDiGraph's postorder because it's defined for irreducible graphs.
* I moved the two_way_conditionals computation out of DerivedGraphSequence so that we can identify join points which span intervals.
* visit_loop_stmt() for ASTExprPropagator is a placeholder. I was also unsure of what the correct implementations are for computing liveness for some of the new statements.
* I have some notes on the modifications made to Cifuentes' algorithms [here](https://gitlab.com/aarnolabs/amp/mram-patching/-/blob/master/mram-docs/loop-reconstruction.md).


