### PR TITLE
Loops

### DIFF
--- a/chb/app/Cfg.py
+++ b/chb/app/Cfg.py
@@ -46,6 +46,8 @@ from typing import (
     Tuple,
     TYPE_CHECKING, Union)
 
+from dataclasses import dataclass
+
 from chb.app.CfgBlock import CfgBlock
 from chb.app.DerivedGraphSequence import DerivedGraphSequence
 
@@ -61,6 +63,268 @@ if TYPE_CHECKING:
     from chb.app.Function import Function
 
 
+
+UserNodeID = str # NewType('UserNodeID', str)
+
+class FlowGraph:
+
+    def __init__(self, nodes: Sequence[UserNodeID], edges: Mapping[UserNodeID, Sequence[UserNodeID]], start_node: UserNodeID):
+        self.nodes = nodes
+        self.edges = edges
+        self.start_node = start_node
+        self._rpo: Dict[UserNodeID, int] = {}
+        self._rpo_sorted: List[UserNodeID] = []
+        self._edge_flavors: Dict[Tuple[UserNodeID, UserNodeID], str] = {}
+        self._revedges: Dict[str, List[str]] = {}
+        self._idoms: Dict[UserNodeID, UserNodeID] = {}
+
+        self._compute_dfs() # First DFS computes the reverse postorder list.
+        self._compute_dfs() # DFS in RPO order can produce fewer cross edges.
+        self._compute_doms()
+
+    def _compute_dfs(self) -> None:
+        """Initializes the reverse postorder list."""
+        visited = set()
+        starttime = {v:0 for v in self.nodes}
+        endtime = {v:0 for v in self.nodes}
+        vtime = 0
+
+        prev_rpo = self._rpo_sorted
+        self._rpo_sorted = []
+        self._rpo = {}
+
+        def visit(node: str) -> None:
+            nonlocal vtime
+            visited.add(node)
+            starttime[node] = vtime
+            vtime += 1
+
+            # Set iteration order is nondeterministic, so we must sort to ensure determinism.
+            successors = sorted(self.post(node))
+            if len(prev_rpo) > 0:
+                succ_idxs = sorted(prev_rpo.index(x) for x in successors)
+                successors = [prev_rpo[i] for i in succ_idxs]
+
+            # Doing DFS a second time, visiting the successors in reverse postorder,
+            # helps to avoid unnecessary cross edges.
+            for t in successors:
+                if t not in visited:
+                    self._edge_flavors[(node, t)] = "tree"
+                    visit(t)
+                else:
+                    if endtime[t] == 0: # starttime[t] < starttime[node] and endtime[t] > endtime[node]:
+                        self._edge_flavors[(node, t)] = "back"
+                    elif starttime[t] > starttime[node]: # and endtime[t] < endtime[node]:
+                        self._edge_flavors[(node, t)] = "forward"
+                    else: # starttime[t] < starttime[node] and endtime[t] < endtime[node]:
+                        self._edge_flavors[(node, t)] = "cross"
+
+            endtime[node] = vtime
+            vtime += 1
+
+            self._rpo_sorted.append(node)
+
+        visit(self.start_node)
+        self._rpo_sorted.reverse()
+
+    def edge_flavor(self, src: UserNodeID, tgt: UserNodeID) -> str:
+        """
+        Returns the flavor of the edge ('back', 'forward', 'cross', 'tree') from src to tgt.
+        """
+        return self._edge_flavors[(src, tgt)]
+
+    @property
+    def revedges(self) -> Dict[str, List[str]]:
+        if len(self._revedges) == 0:
+            for src in self.edges:
+                for tgt in self.edges[src]:
+                    self._revedges.setdefault(tgt, [])
+                    self._revedges[tgt].append(src)
+        return self._revedges
+
+    @property
+    def rpo_sorted(self) -> List[UserNodeID]:
+        """
+        Returns a list of the graph's nodes in a reverse postorder.
+        """
+        return self._rpo_sorted
+
+    @property
+    def rpo(self) -> Dict[UserNodeID, int]:
+        """
+        Returns a mapping from address to index in the reverse postorder.
+        """
+        if len(self._rpo) == 0:
+            self._rpo = {k:i+1 for i, k in enumerate(self.rpo_sorted)}
+        return self._rpo
+
+    def post(self, n) -> Set[str]:
+        if n in self.edges:
+            return set(self.edges[n])
+        else:
+            return set([])
+
+    def pre(self, n) -> Set[str]:
+        if n in self.revedges:
+            return set(self.revedges[n])
+        else:
+            return set([])
+
+    def inverse_with_phantom_exit_node(self) -> 'FlowGraph':
+        """
+        Returns the inverse of the graph, .
+        """
+        phantomend = '__' + str(len(self.nodes))
+        augedges = self.revedges.copy()
+        terminators = [node for node in self.nodes if len(self.post(node)) == 0]
+        augedges[phantomend] = terminators
+        return FlowGraph(list(self.nodes) + [phantomend], augedges, phantomend)
+
+    def ipostdoms(rrg: 'FlowGraph') -> Dict[UserNodeID, UserNodeID]:
+        idoms = rrg.idoms.copy()
+        # The start node of the reverse graph is a phantom node that doesn't
+        # exist in the original graph.
+        del idoms[rrg.start_node]
+        return idoms
+
+    def _compute_doms(self) -> None:
+        """
+        Computes the dominators of each node.
+
+        Implements the algorithm in:
+            "A Simple, Fast Dominance Algorithm"
+            Keith D. Cooper, Timothy J. Harvey, and Ken Kennedy
+            https://www.cs.rice.edu/~keith/EMBED/dom.pdf
+        """
+
+        idoms: Dict[UserNodeID, Optional[UserNodeID]] = {n:None for n in self.nodes}
+
+        def intersect(b1: UserNodeID, b2: UserNodeID) -> UserNodeID:
+            def idom(n: UserNodeID) -> UserNodeID:
+                i = idoms[n]
+                assert i is not None # Should always hit start node.
+                return cast(UserNodeID, i)
+
+            finger1: UserNodeID = b1
+            finger2: UserNodeID = b2
+            while finger1 != finger2:
+                # The paper describes comparisons on postorder numbers; we're using
+                # the reverse postorder numbers, so we need to flip the comparison.
+                while self.rpo[finger1] > self.rpo[finger2]:
+                    finger1 = idom(finger1)
+                while self.rpo[finger2] > self.rpo[finger1]:
+                    finger2 = idom(finger2)
+            return finger1
+
+        # Initialize the dominators of the start node to be the start node itself.
+        idoms[self.start_node] = self.start_node
+        changed = True
+        while changed:
+            changed = False
+            for node in self.rpo_sorted:
+                if node == self.start_node:
+                    continue
+                allpreds = list(self.pre(node))
+                new_idom = None
+                for pred in allpreds:
+                    if idoms[pred] is not None:
+                        new_idom = pred
+                        allpreds.remove(pred) # now it's almost-allpreds...
+                        break
+                assert new_idom is not None
+                for pred in allpreds:
+                    if idoms[pred] is not None:
+                        new_idom = intersect(pred, new_idom)
+                if idoms[node] != new_idom:
+                    idoms[node] = new_idom
+                    changed = True
+
+        # Validate that no node is missing a dominator, justifying the cast.
+        for node in idoms:
+            assert idoms[node] is not None
+        self._idoms = cast(Dict[UserNodeID, UserNodeID], idoms)
+
+    def idom(self, node: UserNodeID) -> UserNodeID:
+        """
+        Returns the immediate dominator of the given node.
+        """
+        return self.idoms[node]
+
+    @property
+    def idoms(self) -> Dict[UserNodeID, UserNodeID]:
+        """
+        Returns a mapping from node to its immediate dominator.
+        """
+        return self._idoms.copy()
+
+    # Linearly bounded by the depth of the dominator tree
+    def dominates(self, node_a: UserNodeID, node_b: UserNodeID) -> bool:
+        """
+        Returns True if node_a dominates node_b.
+        """
+        # Self-domination is implicit.
+        if node_a == node_b:
+            return True
+
+        finger = node_b
+        while finger != self.start_node:
+            if finger == node_a:
+                return True
+            finger = self._idoms[finger]
+        return False
+
+
+def normalized_branch(astree: ASTInterface,
+                      fn: "Function",
+                      n: str,
+                      pcoffset: int,
+                      ifbranch: AST.ASTStmt,
+                      elsebranch: AST.ASTStmt) -> AST.ASTBranch:
+    def cast_binop(condition: Optional[AST.ASTExpr]) -> Optional[AST.ASTBinaryOp]:
+        if condition is None or not condition.is_ast_binary_op:
+            return None
+        return cast(AST.ASTBinaryOp, condition)
+
+    def inverted_binop(condition: Optional[AST.ASTExpr]) -> Optional[AST.ASTBinaryOp]:
+        cond = cast_binop(condition)
+        if cond is not None:
+            invert = {"ne": "eq", "eq": "ne",
+                      "lt": "ge", "ge": "lt",
+                      "gt": "le", "le": "gt"}
+            if cond.op not in ["lor", "land"]:
+                binexpr = astree.mk_binary_expression(invert[cond.op], cond.exp1, cond.exp2)
+                return cast(AST.ASTBinaryOp, binexpr)
+        return None
+
+    def swapped(condition):
+        return astree.mk_branch(condition, elsebranch, ifbranch, pcoffset)
+
+    condition = fn.blocks[n].assembly_ast_condition(astree)
+    couqitiou = inverted_binop(condition)
+    if couqitiou is not None:
+        inverting_eliminates_negation = couqitiou.op == "eq"
+        if ifbranch.is_empty() or (inverting_eliminates_negation and not elsebranch.is_empty()):
+            return swapped(couqitiou)
+
+    if ifbranch.is_empty():
+        return swapped(fn.blocks[n].assembly_ast_condition(astree, reverse=True))
+
+    return cast(AST.ASTBranch, astree.mk_branch(condition, ifbranch, elsebranch, pcoffset))
+
+
+@dataclass
+class ControlFlowContext:
+    break_to: Optional[str]
+    continue_to: Optional[str]
+    fallthrough: Optional[str]
+
+    def in_loop(self, x: str) -> 'ControlFlowContext':
+        return ControlFlowContext(self.fallthrough, x, x)
+
+    def with_fallthrough(self, f: str) -> 'ControlFlowContext':
+        return ControlFlowContext(self.break_to, self.continue_to, f)
+
+
 class Cfg:
 
     def __init__(
@@ -71,6 +335,7 @@ class Cfg:
         self.xnode = xnode
         self._edges: Dict[str, List[str]] = {}
         self._graphseq: Optional[DerivedGraphSequence] = None
+        self._flowgraph: Optional[FlowGraph] = None
 
     @property
     def faddr(self) -> str:
@@ -139,75 +404,119 @@ class Cfg:
     def rpo_sorted_nodes(self) -> List[str]:
         """Return a list of block addresses in reverse postorder."""
 
-        if self.is_reducible:
-            return self.derived_graph_sequence.rpo_sorted_nodes
-        else:
-            return []
+        return self.flowgraph.rpo_sorted
+
+    @property
+    def flowgraph(self) -> FlowGraph:
+        if self._flowgraph is None:
+            self._flowgraph = FlowGraph(self.derived_graph_sequence.nodes,
+                                    self.derived_graph_sequence.edges,
+                                    self.derived_graph_sequence.graphs[0].nodes[0])
+        return self._flowgraph
 
     def stmt_ast(
             self,
             fn: "Function",
             astree: ASTInterface,
             blockstmts: Dict[str, AST.ASTStmt]) -> AST.ASTStmt:
-        twowayconds = self.derived_graph_sequence.two_way_conditionals()
 
-        def construct(
-                n: str,
-                follow: Optional[str],
-                result: List[AST.ASTStmt]) -> AST.ASTStmt:
-            if follow and n == follow:
-                return astree.mk_block(result)
-            elif len(self.successors(n)) == 0:
-                return astree.mk_block(result + [blockstmts[n]])
-            elif len(self.successors(n)) == 1:
-                return construct(
-                    self.successors(n)[0], follow, result + [blockstmts[n]])
-            elif len(self.successors(n)) == 2:
-                if n in twowayconds:
-                    follownode: Optional[str] = twowayconds[n]
-                else:
-                    follownode = None
-                ifbranch = construct(self.successors(n)[1], follownode, [])
-                elsebranch = construct(self.successors(n)[0], follownode, [])
-                pcoffset = (
-                    (int(self.successors(n)[1], 16)
-                     - int(self.successors(n)[0], 16))
-                    - 2)
-                if ifbranch.is_empty():
-                    condition = fn.blocks[n].assembly_ast_condition(
-                        astree, reverse=True)
-                    bstmt = astree.mk_branch(
-                        condition, elsebranch, ifbranch, pcoffset)
-                else:
-                    condition = fn.blocks[n].assembly_ast_condition(astree)
-                    if (
-                            (not elsebranch.is_empty())
-                            and condition
-                            and condition.is_ast_binary_op):
-                        cond = cast(AST.ASTBinaryOp, condition)
-                        if cond.op in ["neq", "ne"]:
-                            condition = astree.mk_binary_expression(
-                                "eq", cond.exp1, cond.exp2)
-                            bstmt = astree.mk_branch(
-                                condition, elsebranch, ifbranch, pcoffset)
-                        else:
-                            bstmt = astree.mk_branch(
-                                condition, ifbranch, elsebranch, pcoffset)
-                    else:
-                        bstmt = astree.mk_branch(
-                            condition, ifbranch, elsebranch, pcoffset)
-                branchinstr = fn.blocks[n].last_instruction
-                astree.add_instruction_span(
-                    bstmt.locationid, branchinstr.iaddr, branchinstr.bytestring)
-                if follownode:
-                    return construct(
-                        follownode, follow, result + [blockstmts[n], bstmt])
-                else:
-                    return astree.mk_block(result + [blockstmts[n], bstmt])
-            else:
-                raise UF.CHBError("Multi branch for " + n)
+        def expand_domtree() -> Dict[str, List[str]]:
+            domtree_adj: Dict[str, List[str]] = dict()
+            for node, idom in self.flowgraph._idoms.items():
+                # nodes point to those they dominate
+                if not idom in domtree_adj:
+                    domtree_adj[idom] = []
+                domtree_adj[idom].append(node)
 
-        return construct(self.faddr, None, [])
+            for x in domtree_adj:
+                # highest rpo first, since nodeWithin places them in reverse order
+                domtree_adj[x].sort(key=lambda x: self.flowgraph.rpo[x], reverse=True)
+            return domtree_adj
+
+        def mk_block(stmts: List[AST.ASTStmt]) -> AST.ASTStmt:
+            if len(stmts) == 1 and not stmts[0].is_ast_instruction_sequence:
+                return stmts[0]
+            return astree.mk_block(stmts)
+
+        gotolabels: Set[str] = set() # this is both used and mutated by run_with_gotolabels()
+        domtree_adj = expand_domtree()
+
+        def run_with_gotolabels() -> AST.ASTStmt:
+            # This beautifully compact algorithm is due to
+            #       Norman Ramsey. 2022. Beyond Relooper: Recursive Translation of
+            #       Unstructured Control Flow to Structured Control Flow: Functional Pearl.
+            #       Proc. ACM Program. Lang. 1, 1 (June 2022)
+            # In short, we use the dominator tree, tracking the control flow context
+            # of the AST we build, to build an AST which emits every block once and
+            # uses jumps or fallthroughs as appropriate. Rather than pre-computing the
+            # targets of goto statements, we just record which ones we need,
+            # and run the algorithm twice to ensure nodes which need them get labels.
+            #
+            # Results for irreducible CFGs will be correct but not necessarily pretty.
+
+            def do_tree(x: str, ctx: ControlFlowContext) -> List[AST.ASTStmt]:
+                children = domtree_adj[x] if x in domtree_adj else []
+                merges = [c for c in children if is_merge_node(c)]
+                if is_loop_header(x):
+                    return [astree.mk_loop(mk_block(node_within(x, merges, ctx.in_loop(x))))]
+                return node_within(x, merges, ctx)
+
+            def do_branch(src: str, tgt: str, ctx: ControlFlowContext) -> List[AST.ASTStmt]:
+                if not is_backward(src, tgt) and not is_merge_node(tgt):
+                    return do_tree(tgt, ctx)
+
+                if tgt == ctx.fallthrough:
+                    return []
+
+                if tgt == ctx.continue_to:
+                    return [astree.mk_continue_stmt()]
+
+                if tgt == ctx.break_to:
+                    return [astree.mk_break_stmt()]
+
+                gotolabels.add(tgt)
+                return [astree.mk_goto_stmt(tgt)]
+
+            def is_loop_header(x: str) -> bool:
+                return any(is_backward(pred, x) for pred in self.flowgraph.pre(x))
+
+            def is_merge_node(x: str) -> bool:
+                return len(self.flowgraph.pre(x)) >= 2
+
+            def is_backward(src: str, tgt: str) -> bool:
+                # Could compare rpo numbers instead but this seems clearer.
+                return self.flowgraph._edge_flavors[(src, tgt)] == "back"
+
+            def node_within(x: str, merges: List[str], ctx: ControlFlowContext) -> List[AST.ASTStmt]:
+                if len(merges) >= 1:
+                    y_n, ys = merges[0], merges[1:]
+                    return node_within(x, ys, ctx.with_fallthrough(y_n)) + do_tree(y_n, ctx)
+
+                succs = self.successors(x)
+                nsuccs = len(succs)
+                xstmt = blockstmts[x]
+                if x in gotolabels:
+                    # TODO(brk): toggle label on xstmt
+                    pass
+                xstmts = [xstmt]
+                if nsuccs == 0:
+                    return xstmts # TODO(brk): and return statement?
+
+                if nsuccs == 1:
+                    return xstmts + do_branch(x, succs[0], ctx)
+
+                assert nsuccs == 2
+                ifbranch = mk_block(do_branch(x, succs[1], ctx))
+                elsebranch = mk_block(do_branch(x, succs[0], ctx))
+                pcoffset = pcoffset = ( (int(succs[1], 16) - int(succs[0], 16)) - 2)
+                return xstmts + [normalized_branch(astree, fn, x, pcoffset, ifbranch, elsebranch)]
+
+            initial = ControlFlowContext(None, None, None)
+            return mk_block(do_tree(self.flowgraph.start_node, initial))
+
+        # First run collects the labels; the next run uses them.
+        run_with_gotolabels()
+        return run_with_gotolabels()
 
     def assembly_ast(
             self,

--- a/chb/app/DerivedGraphSequence.py
+++ b/chb/app/DerivedGraphSequence.py
@@ -38,7 +38,7 @@ import chb.util.dotutil as UD
 
 
 class GraphInterval:
-    """Maximual single-entry subgraph in which the header node appears in all closed paths."""
+    """Maximal single-entry subgraph in which the header node appears in all closed paths."""
 
     def __init__(self, header: str) -> None:
         self._header = header
@@ -137,58 +137,6 @@ class GraphInterval:
                     continue
                 self._idom[n] = max(self.dom[n] - set([n]), key=lambda k: self.rpo[k])
         return self._idom
-
-    @property
-    def two_way_conditionals(self) -> Dict[str, str]:
-        """Identify 2-way conditionals and their follow nodes.
-
-        Based on algorithm in:
-        Cristina Cifuentes, Structuring Decompiled Graphs, Compiler Construction,
-        CC'96, LNCS 1060, pg 91-105, Springer, 1996.
-        """
-
-        def find_follow(m: str) -> Optional[str]:
-            followcandidates: List[str] = [
-                i for i in self.nodes
-                if i != self.header and self.idom[i] == m and len(self.pre(i)) >= 2]
-            if len(followcandidates) > 0:
-                return max(followcandidates, key=lambda k: self.rpo[k])
-            else:
-                return None
-
-        def is_descendant(child: str, parent: str) -> bool:
-            for i in self.post(parent):
-                if child == i:
-                    return True
-                if is_descendant(child, i):
-                    return True
-            return False
-
-        unresolved: Set[str] = set([])
-
-        if len(self._twowayconditionals) == 0:
-            for m in self.rpo_revsorted_nodes:
-                if (
-                        len(self.post(m)) == 2       # 2-way conditional
-                        and ((not m == self.header)
-                             or len(self.pre(m)) == 0)  # not a loop header
-                        and self.header not in self.post(m)):  # not a latching node
-                    follow = find_follow(m)
-                    if follow is not None:
-                        self._twowayconditionals[m] = follow
-                        toberemoved: List[str] = []
-                        for k in unresolved:
-                            if is_descendant(follow, k):
-                                self._twowayconditionals[k] = follow
-                                toberemoved.append(k)
-                        for k in toberemoved:
-                            unresolved.remove(k)
-                    else:
-                        unresolved.add(m)
-
-        if len(unresolved) > 0:
-            print("Unresolved two-way conditional: " + ", ".join(unresolved))
-        return self._twowayconditionals
 
     def post(self, n) -> Set[str]:
         if n in self.edges:
@@ -474,7 +422,7 @@ class DerivedGraphSequence:
         """Return hierarchical reverse postorder on all nodes."""
 
         prevrpo: Dict[str, List[int]] = {}
-        if self.graphs[-1].size == 1:
+        if self.is_reducible:
             header = self.graphs[-1].nodes[0]
             prevrpo = {header: [0]}
             for g in self.graphs[:-1][::-1]:
@@ -498,17 +446,12 @@ class DerivedGraphSequence:
             self._graphs.append(g)
 
     def to_dot(self, path: str, out: str):
-        rpo = self.graphs[-1].size == 1
         for (i, g) in enumerate(self.graphs):
             pdffilename = UD.print_dot(
                 path,
                 out + str(i+1),
-                g.to_dot("G" + str(i+1), rpo=self.hrpo, showintervals=True))
+                g.to_dot("G" + str(i+1), rpo=self.hrpo, showintervals=self.is_reducible))
             print(pdffilename)
-
-    def two_way_conditionals(self) -> Dict[str, str]:
-        i = list(self.graphs[0].intervals.values())[0]
-        return i.two_way_conditionals
 
     def __str__(self) -> str:
         lines: List[str] = []

--- a/chb/ast/ASTByteSizeCalculator.py
+++ b/chb/ast/ASTByteSizeCalculator.py
@@ -127,6 +127,15 @@ class ASTByteSizeCalculator(ASTIndexer):
     def index_return_stmt(self, stmt: AST.ASTReturn) -> int:
         return 0
 
+    def index_break_stmt(self, stmt: AST.ASTBreak) -> int:
+        return 0
+
+    def index_continue_stmt(self, stmt: AST.ASTContinue) -> int:
+        return 0
+
+    def index_loop_stmt(self, stmt: AST.ASTLoop) -> int:
+        return 0
+
     def index_block_stmt(self, stmt: AST.ASTBlock) -> int:
         return 0
 

--- a/chb/ast/ASTCPrettyPrinter.py
+++ b/chb/ast/ASTCPrettyPrinter.py
@@ -184,6 +184,14 @@ class ASTCPrettyPrinter(ASTVisitor):
     def stmt_to_c(self, stmt: AST.ASTStmt) -> None:
         if stmt.is_ast_return:
             self.visit_return_stmt(cast(AST.ASTReturn, stmt))
+        elif stmt.is_ast_break:
+            self.visit_break_stmt(cast(AST.ASTBreak, stmt))
+        elif stmt.is_ast_continue:
+            self.visit_continue_stmt(cast(AST.ASTContinue, stmt))
+        elif stmt.is_ast_goto:
+            self.visit_goto_stmt(cast(AST.ASTGoto, stmt))
+        elif stmt.is_ast_loop:
+            self.visit_loop_stmt(cast(AST.ASTLoop, stmt))
         elif stmt.is_ast_block:
             self.visit_block_stmt(cast(AST.ASTBlock, stmt))
         elif stmt.is_ast_instruction_sequence:
@@ -208,6 +216,22 @@ class ASTCPrettyPrinter(ASTVisitor):
             self.ccode.write(";")
         else:
             self.ccode.write("return;")
+
+    def visit_break_stmt(self, stmt: AST.ASTBreak) -> None:
+        self.ccode.newline(indent=self.indent)
+        self.ccode.write("break;")
+
+    def visit_continue_stmt(self, stmt: AST.ASTContinue) -> None:
+        self.ccode.newline(indent=self.indent)
+        self.ccode.write("continue;")
+
+    def visit_loop_stmt(self, stmt: AST.ASTLoop) -> None:
+        self.ccode.write("while (1) {")
+        self.increase_indent()
+        for s in stmt.stmts:
+            s.accept(self)
+        self.decrease_indent()
+        self.ccode.write("}")
 
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
         for label in stmt.labels:

--- a/chb/ast/ASTCTyper.py
+++ b/chb/ast/ASTCTyper.py
@@ -41,6 +41,15 @@ class ASTCTyper(ABC):
     def ctype_return_stmt(self, stmt: AST.ASTReturn) -> Optional[AST.ASTTyp]:
         return None
 
+    def ctype_break_stmt(self, stmt: AST.ASTBreak) -> Optional[AST.ASTTyp]:
+        return None
+
+    def ctype_continue_stmt(self, stmt: AST.ASTContinue) -> Optional[AST.ASTTyp]:
+        return None
+
+    def ctype_loop_stmt(self, stmt: AST.ASTLoop) -> Optional[AST.ASTTyp]:
+        return None
+
     def ctype_block_stmt(self, stmt: AST.ASTBlock) -> Optional[AST.ASTTyp]:
         return None
 

--- a/chb/ast/ASTIndexer.py
+++ b/chb/ast/ASTIndexer.py
@@ -41,6 +41,18 @@ class ASTIndexer(ABC):
         ...
 
     @abstractmethod
+    def index_break_stmt(self, stmt: AST.ASTBreak) -> int:
+        ...
+
+    @abstractmethod
+    def index_continue_stmt(self, stmt: AST.ASTContinue) -> int:
+        ...
+
+    @abstractmethod
+    def index_loop_stmt(self, stmt: AST.ASTLoop) -> int:
+        ...
+
+    @abstractmethod
     def index_block_stmt(self, stmt: AST.ASTBlock) -> int:
         ...
 

--- a/chb/ast/ASTNOPVisitor.py
+++ b/chb/ast/ASTNOPVisitor.py
@@ -38,6 +38,15 @@ class ASTNOPVisitor(ASTVisitor):
     def visit_return_stmt(self, stmt: AST.ASTReturn) -> None:
         pass
 
+    def visit_break_stmt(self, stmt: AST.ASTBreak) -> None:
+        pass
+
+    def visit_continue_stmt(self, stmt: AST.ASTContinue) -> None:
+        pass
+
+    def visit_loop_stmt(self, stmt: AST.ASTLoop) -> None:
+        pass
+
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
         pass
 

--- a/chb/ast/ASTNode.py
+++ b/chb/ast/ASTNode.py
@@ -217,7 +217,7 @@ class ASTStmt(ASTNode):
         ASTNode.__init__(self, tag)
         self._stmtid = stmtid
         self._locationid = locationid
-        self._labels = labels
+        self._labels = labels.copy() # avoid unwanted aliasing
 
     @property
     def stmtid(self) -> int:
@@ -230,6 +230,9 @@ class ASTStmt(ASTNode):
     @property
     def labels(self) -> List["ASTStmtLabel"]:
         return self._labels
+
+    def add_label(self, name: str) -> None:
+        self._labels.append(ASTLabel(self.locationid, name))
 
     @property
     def is_ast_stmt(self) -> bool:

--- a/chb/ast/ASTSerializer.py
+++ b/chb/ast/ASTSerializer.py
@@ -323,10 +323,12 @@ class ASTSerializer(ASTIndexer):
             node["labelcount"] = len(stmt.labels)
             for label in stmt.labels:
                 args.append(label.index(self))
-        for s in stmt.stmts:
-            if s.is_ast_instruction_sequence and len(s.instructions) == 0:
-                continue
-            args.append(s.index(self))
+        def is_empty_instr_sequence(s: AST.ASTStmt) -> bool:
+            if not s.is_ast_instruction_sequence:
+                return False
+            return len(cast(AST.ASTInstrSequence, s).instructions) == 0
+        args.extend(s.index(self) for s in stmt.stmts \
+                        if not is_empty_instr_sequence(s))
         return self.add(tags, args, node)
 
     def index_loop_stmt(self, stmt: AST.ASTLoop) -> int:

--- a/chb/ast/ASTSerializer.py
+++ b/chb/ast/ASTSerializer.py
@@ -325,6 +325,14 @@ class ASTSerializer(ASTIndexer):
                 args.append(label.index(self))
         return self.add(tags, args, node)
 
+    def index_loop_stmt(self, stmt: AST.ASTLoop) -> int:
+        tags: List[str] = [stmt.tag, str(stmt.stmtid), str(stmt.locationid)]
+        args: List[int] = [s.index(self) for s in stmt.stmts]
+        node: Dict[str, Any] = {"tag": stmt.tag}
+        node["stmtid"] = stmt.stmtid
+        node["locationid"] =  stmt.locationid
+        return self.add(tags, args, node)
+
     def index_branch_stmt(self, stmt: AST.ASTBranch) -> int:
         tags: List[str] = [
             stmt.tag, str(stmt.stmtid),
@@ -363,6 +371,24 @@ class ASTSerializer(ASTIndexer):
         node["destination"] = stmt.destination
         for label in stmt.labels:
             args.append(label.index(self))
+        return self.add(tags, args, node)
+
+    def index_break_stmt(self, stmt: AST.ASTBreak) -> int:
+        tags: List[str] = [
+            stmt.tag, str(stmt.stmtid), str(stmt.locationid), str(stmt.locationid)]
+        args: List[int] = []
+        node: Dict[str, Any] = {"tag": stmt.tag}
+        node["stmtid"] = stmt.stmtid
+        node["locationid"] = stmt.locationid
+        return self.add(tags, args, node)
+
+    def index_continue_stmt(self, stmt: AST.ASTContinue) -> int:
+        tags: List[str] = [
+            stmt.tag, str(stmt.stmtid), str(stmt.locationid), str(stmt.locationid)]
+        args: List[int] = []
+        node: Dict[str, Any] = {"tag": stmt.tag}
+        node["stmtid"] = stmt.stmtid
+        node["locationid"] = stmt.locationid
         return self.add(tags, args, node)
 
     def index_switch_stmt(self, stmt: AST.ASTSwitchStmt) -> int:

--- a/chb/ast/ASTTransformer.py
+++ b/chb/ast/ASTTransformer.py
@@ -41,6 +41,18 @@ class ASTTransformer(ABC):
         ...
 
     @abstractmethod
+    def transform_break_stmt(self, stmt: AST.ASTBreak) -> AST.ASTStmt:
+        ...
+
+    @abstractmethod
+    def transform_continue_stmt(self, stmt: AST.ASTContinue) -> AST.ASTStmt:
+        ...
+
+    @abstractmethod
+    def transform_loop_stmt(self, stmt: AST.ASTLoop) -> AST.ASTStmt:
+        ...
+
+    @abstractmethod
     def transform_block_stmt(self, stmt: AST.ASTBlock) -> AST.ASTStmt:
         ...
 

--- a/chb/ast/ASTVariablesReferenced.py
+++ b/chb/ast/ASTVariablesReferenced.py
@@ -50,6 +50,16 @@ class ASTVariablesReferenced(ASTVisitor):
         if stmt.has_return_value():
             stmt.expr.accept(self)
 
+    def visit_break_stmt(self, stmt: AST.ASTBreak) -> None:
+        pass
+
+    def visit_continue_stmt(self, stmt: AST.ASTContinue) -> None:
+        pass
+
+    def visit_loop_stmt(self, stmt: AST.ASTLoop) -> None:
+        for s in stmt.stmts:
+            s.accept(self)
+
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
         for s in stmt.stmts:
             s.accept(self)

--- a/chb/ast/ASTVisitor.py
+++ b/chb/ast/ASTVisitor.py
@@ -42,6 +42,18 @@ class ASTVisitor(ABC):
         ...
 
     @abstractmethod
+    def visit_break_stmt(self, stmt: AST.ASTBreak) -> None:
+        ...
+
+    @abstractmethod
+    def visit_continue_stmt(self, stmt: AST.ASTContinue) -> None:
+        ...
+
+    @abstractmethod
+    def visit_loop_stmt(self, stmt: AST.ASTLoop) -> None:
+        ...
+
+    @abstractmethod
     def visit_block_stmt(self, stmt: AST.ASTBlock) -> None:
         ...
 

--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -212,6 +212,32 @@ class AbstractSyntaxTree:
         locationid = self.get_locationid(optlocationid)
         return AST.ASTReturn(stmtid, locationid, expr, labels=labels)
 
+    def mk_loop(
+            self,
+            body: AST.ASTStmt,
+            optstmtid: Optional[int] = None,
+            optlocationid: Optional[int] = None) -> AST.ASTLoop:
+        stmtid = self.get_stmtid(optstmtid)
+        locationid = self.get_locationid(optlocationid)
+        return AST.ASTLoop(stmtid, locationid, body)
+
+
+    def mk_break_stmt(
+            self,
+            optstmtid: Optional[int] = None,
+            optlocationid: Optional[int] = None) -> AST.ASTBreak:
+        stmtid = self.get_stmtid(optstmtid)
+        locationid = self.get_locationid(optlocationid)
+        return AST.ASTBreak(stmtid, locationid)
+
+    def mk_continue_stmt(
+            self,
+            optstmtid: Optional[int] = None,
+            optlocationid: Optional[int] = None) -> AST.ASTContinue:
+        stmtid = self.get_stmtid(optstmtid)
+        locationid = self.get_locationid(optlocationid)
+        return AST.ASTContinue(stmtid, locationid)
+
     def mk_branch(
             self,
             condition: Optional[AST.ASTExpr],

--- a/chb/ast/doc/README.md
+++ b/chb/ast/doc/README.md
@@ -31,7 +31,10 @@ syntax tree. They are organized in a hierarchy as follows:
 
 - **ASTStmt**: abstract control flow statement
   - *ASTReturn*: return statement
+  - *ASTBreak*: break statement
+  - *ASTContinue*: continue statement
   - *ASTBlock*: sequence of control flow statements
+  - *ASTLoop*: endlessly-repeated statement
   - *ASTInstrSequence*: sequence of instructions (basic block)
   - *ASTBranch*: if-then-else branch statement
   - *ASTSwitch*: swith statement

--- a/chb/ast/doc/api.md
+++ b/chb/ast/doc/api.md
@@ -274,7 +274,7 @@ relate the statement to a location in the binary.
 Variables have a name. For named variables it is the user's responsibility
 to ensure that distinct variables (i.e. distinct storage locations) have
 distinct names (within a function) and that distinct global variables have
-distinct names (across all functions). Local variables in different\
+distinct names (across all functions). Local variables in different
 functions may have the same name (functions have different name spaces).
 
 The basic data structure for a variable is the ASTVarInfo, which holds the
@@ -284,9 +284,9 @@ address is known, and an optional description of what the variable holds.
 The varinfo is stored in the local or global symbol table on first creation.
 
 The first creation of the varinfo determines the associate data. Once a
-variable exists (either in the global symbol or local symbol table)
+variable exists (either in the global or local symbol table)
 subsequent calls to create a variable with the same name (in the same name
-space result in retrieval of the existing varinfo rather than creating a
+space) result in retrieval of the existing varinfo rather than creating a
 new one, thereby ignoring the associate data provided.
 
 Only one instance exists of the ASTVarInfo data structure, held in the

--- a/chb/ast/doc/api.md
+++ b/chb/ast/doc/api.md
@@ -64,6 +64,16 @@ not present a new value is generated automatically.
     labels: List[ASTLabel] = []) -> ASTBlock
   ```
 
+- **mk_loop**: repeats the given statement (which will often be a block)
+  by wrapping it with an infinite loop construct (e.g. `while (1)`).
+  ```
+  def mk_loop(
+    self,
+    body: AST.ASTStmt,
+    stmtid: Optional[int] = None,
+    locationid: Optional[int] = None) -> AST.ASTLoop
+  ```
+
 - **mk_return_stmt**: creates a return statement with an optional
   return expression.
   ```
@@ -72,6 +82,20 @@ not present a new value is generated automatically.
     stmtid: Optional[int],
     locationid: Optional[int],
     labels: List[ASTLabel] = []) -> ASTReturn
+  ```
+
+- **mk_break_stmt**: creates a break statement.
+  ```
+  def mk_break_stmt(self,
+    stmtid: Optional[int],
+    locationid: Optional[int]) -> ASTBreak
+  ```
+
+- **mk_continue_stmt**: creates a continue statement.
+  ```
+  def mk_continue_stmt(self,
+    stmtid: Optional[int],
+    locationid: Optional[int]) -> ASTBreak
   ```
 
 - **mk_branch**: creates a if-then-else statement with a condition

--- a/chb/astinterface/ASTInterface.py
+++ b/chb/astinterface/ASTInterface.py
@@ -378,11 +378,20 @@ class ASTInterface:
             labels: List[AST.ASTStmtLabel] = []) -> AST.ASTBlock:
         return self.astree.mk_block(stmts, labels=labels)
 
+    def mk_loop(self, body: AST.ASTStmt) -> AST.ASTLoop:
+        return self.astree.mk_loop(body)
+
     def mk_return_stmt(
             self,
             expr: Optional[AST.ASTExpr],
             labels: List[AST.ASTStmtLabel] = []) -> AST.ASTReturn:
         return self.astree.mk_return_stmt(expr, labels=labels)
+
+    def mk_break_stmt(self) -> AST.ASTBreak:
+        return self.astree.mk_break_stmt()
+
+    def mk_continue_stmt(self) -> AST.ASTContinue:
+        return self.astree.mk_continue_stmt()
 
     def mk_branch(
             self,


### PR DESCRIPTION
This is so much prettier than the previous attempt.

Should be mypy-clean.

I had to make the labels attribute mutable because we only know which labels are necessary after the AST statements have been created. I also tweaked the serialization to print labels at the start of blocks/instr sequences.

Break and continue statements do not have labels (in their constructors) because they correspond to edges in the CFG, not nodes. This is, I guess, a reflection of how CIL must deal with source as written, and we're more interested in the semantics. (I did not remove the labels from the existing constructor for gotos.)