### PR TITLE
Tweak two tiny typos.

### DIFF
--- a/chb/ast/ASTApplicationInterface.py
+++ b/chb/ast/ASTApplicationInterface.py
@@ -91,7 +91,7 @@ class ASTApplicationInterface:
         fndata["ast"] = {}
         fndata["ast"]["nodes"] = astnodes
         fndata["ast"]["ast-startnode"] = ast_startindex
-        fndata["ast"]["cfg-ast-stargnode"] = cfg_startindex
+        fndata["ast"]["cfg-ast-startnode"] = cfg_startindex
         fndata["spans"] = astree.spans
         fndata["available-expressions"] = {}
 

--- a/chb/ast/doc/README.md
+++ b/chb/ast/doc/README.md
@@ -34,7 +34,7 @@ syntax tree. They are organized in a hierarchy as follows:
   - *ASTBlock*: sequence of control flow statements
   - *ASTInstrSequence*: sequence of instructions (basic block)
   - *ASTBranch*: if-then-else branch statement
-  - *ASTSwitch*: swith statement
+  - *ASTSwitch*: switch statement
   - *ASTGoto*: goto statement
 - **ASTStmtLabel**:
   - *ASTLabel*: label for goto destination statements


### PR DESCRIPTION
Vim also seems to have taken the liberty of inserting a newline at the end of the file.