### PR TITLE
add extra function to ASTApplicationInterface to pass already built ASTs

### DIFF
--- a/chb/ast/AbstractSyntaxTree.py
+++ b/chb/ast/AbstractSyntaxTree.py
@@ -115,6 +115,10 @@ class AbstractSyntaxTree:
         return self._fname
 
     @property
+    def faddr(self) -> str:
+        return self._faddr
+
+    @property
     def symboltable(self) -> ASTLocalSymbolTable:
         return self._symboltable
 


### PR DESCRIPTION
this provides an alternative mechanism for users of the library
to construct the AST while taking advantage of the json serialization
and global symbol table management that ASTApplicationInterface does.

For the BinaryNinja plugin this provides a better fit because
things like the function prototype depend on having an
AbstractSyntaxTree object available, which is not possible
with the way add_function works.

I played a bit with trying to pass the astree to the astfn object
before asking it for the function prototype, but things become
very awkward really fast, it would have required changing the
way CodeHawk builds the AST. Adding this new function seems
to me like it provides the best of worlds without rocking
the boat too much.